### PR TITLE
Main page UI polish and lobby state setup

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,9 @@ import SplashScreen from './Screens/SplashScreen';
 import LoginScreen from './Screens/LoginScreen';
 import SignUpScreen from './Screens/SignUpScreen';
 import HomeScreen from './Screens/HomeScreen';
+import ProfileScreen from './Screens/ProfileScreen';
+import GameDetailsScreen from './Screens/GameDetailsScreen';
+import RatingScreen from './Screens/RatingScreen';
 import ProtectedRoute from './components/ProtectedRoute';
 
 const router = createBrowserRouter([
@@ -15,6 +18,30 @@ const router = createBrowserRouter([
     element: (
       <ProtectedRoute>
         <HomeScreen />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/ProfileScreen',
+    element: (
+      <ProtectedRoute>
+        <ProfileScreen />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/GameDetailsScreen',
+    element: (
+      <ProtectedRoute>
+        <GameDetailsScreen />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/RatingScreen',
+    element: (
+      <ProtectedRoute>
+        <RatingScreen />
       </ProtectedRoute>
     ),
   },

--- a/src/App.js
+++ b/src/App.js
@@ -4,9 +4,6 @@ import SplashScreen from './Screens/SplashScreen';
 import LoginScreen from './Screens/LoginScreen';
 import SignUpScreen from './Screens/SignUpScreen';
 import HomeScreen from './Screens/HomeScreen';
-import ProfileScreen from './Screens/ProfileScreen';
-import GameDetailsScreen from './Screens/GameDetailsScreen';
-import RatingScreen from './Screens/RatingScreen';
 import ProtectedRoute from './components/ProtectedRoute';
 
 const router = createBrowserRouter([
@@ -18,30 +15,6 @@ const router = createBrowserRouter([
     element: (
       <ProtectedRoute>
         <HomeScreen />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/ProfileScreen',
-    element: (
-      <ProtectedRoute>
-        <ProfileScreen />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/GameDetailsScreen',
-    element: (
-      <ProtectedRoute>
-        <GameDetailsScreen />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/RatingScreen',
-    element: (
-      <ProtectedRoute>
-        <RatingScreen />
       </ProtectedRoute>
     ),
   },

--- a/src/Screens/HomeScreen.css
+++ b/src/Screens/HomeScreen.css
@@ -1,11 +1,5 @@
 .home-screen {
-  min-height: 100dvh;
-  background: var(--color-bg);
-  display: flex;
-  flex-direction: column;
-  padding: var(--page-padding-y) var(--page-padding-x);
-  font-family: var(--font-family);
-  color: var(--color-text);
+  padding-bottom: 72px;
 }
 
 .home-content {
@@ -132,9 +126,17 @@
 
 /* ── Bottom nav ── */
 .bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  max-width: 430px;
   display: flex;
   justify-content: flex-end;
-  padding: var(--space-4) 0 var(--space-2) 0;
+  align-items: center;
+  padding: var(--space-4) var(--page-padding-x);
+  background-color: var(--color-bg);
 }
 
 .profile-btn {

--- a/src/Screens/HomeScreen.css
+++ b/src/Screens/HomeScreen.css
@@ -12,7 +12,9 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
   padding-top: var(--space-10);
+  padding-bottom: var(--space-6);
 }
 
 /* ── Hero ── */
@@ -73,6 +75,7 @@
 /* ── Player slots ── */
 .player-slots {
   display: flex;
+  align-items: center;
   gap: var(--space-3);
   margin-bottom: var(--space-8);
 }
@@ -86,6 +89,11 @@
 
 .slot.avatar {
   background: var(--color-icon);
+}
+
+.slot.avatar.empty {
+  background: transparent;
+  border: 2px dashed rgba(255, 255, 255, 0.25);
 }
 
 .slot.add-slot {
@@ -126,7 +134,7 @@
 .bottom-nav {
   display: flex;
   justify-content: flex-end;
-  padding-top: var(--space-5);
+  padding: var(--space-4) 0 var(--space-2) 0;
 }
 
 .profile-btn {
@@ -134,12 +142,13 @@
   border: none;
   color: var(--color-text);
   cursor: pointer;
-  width: 28px;
-  height: 28px;
+  width: 44px;
+  height: 44px;
   padding: 0;
   display: flex;
   align-items: center;
   justify-content: center;
+  opacity: 0.9;
 }
 
 .profile-btn svg {

--- a/src/Screens/HomeScreen.css
+++ b/src/Screens/HomeScreen.css
@@ -1,0 +1,148 @@
+.home-screen {
+  min-height: 100dvh;
+  background: var(--color-bg);
+  display: flex;
+  flex-direction: column;
+  padding: var(--page-padding-y) var(--page-padding-x);
+  font-family: var(--font-family);
+  color: var(--color-text);
+}
+
+.home-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding-top: var(--space-10);
+}
+
+/* ── Hero ── */
+.hero-title {
+  font-size: var(--text-hero);
+  font-weight: var(--font-black);
+  line-height: 0.88;
+  letter-spacing: -0.02em;
+  color: var(--color-text);
+  text-transform: uppercase;
+  margin: 0 0 var(--space-4) 0;
+}
+
+/* ── Mode selector ── */
+.mode-section {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: var(--space-8);
+}
+
+.mode-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.mode-label {
+  font-size: var(--text-xl);
+  font-weight: var(--font-black);
+  color: var(--color-accent);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.settings-btn {
+  background: none;
+  border: none;
+  color: var(--color-text);
+  font-size: var(--text-lg);
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  opacity: 0.85;
+}
+
+.mode-sub {
+  font-size: var(--text-xl);
+  font-weight: var(--font-black);
+  color: var(--color-text);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0;
+}
+
+/* ── Player slots ── */
+.player-slots {
+  display: flex;
+  gap: var(--space-3);
+  margin-bottom: var(--space-8);
+}
+
+.slot {
+  width: 62px;
+  height: 62px;
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+}
+
+.slot.avatar {
+  background: var(--color-icon);
+}
+
+.slot.add-slot {
+  background: var(--color-surface);
+  border: none;
+  color: var(--color-text);
+  font-size: var(--text-2xl);
+  font-weight: var(--font-bold);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+/* ── Search button ── */
+.search-btn {
+  width: 100%;
+  padding: var(--space-5) 0;
+  background: var(--color-surface);
+  border: none;
+  border-radius: var(--radius-lg);
+  color: var(--color-text);
+  font-family: var(--font-family);
+  font-size: var(--text-base);
+  font-weight: var(--font-black);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: opacity var(--transition-fast);
+}
+
+.search-btn:active {
+  opacity: 0.8;
+}
+
+/* ── Bottom nav ── */
+.bottom-nav {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: var(--space-5);
+}
+
+.profile-btn {
+  background: none;
+  border: none;
+  color: var(--color-text);
+  cursor: pointer;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.profile-btn svg {
+  width: 100%;
+  height: 100%;
+}

--- a/src/Screens/HomeScreen.js
+++ b/src/Screens/HomeScreen.js
@@ -1,23 +1,101 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { supabase } from '../supabaseClient';
+import LobbyInviteModal from '../components/LobbyInviteModal';
+import ModifyGameModal from '../components/ModifyGameModal';
+import './HomeScreen.css';
+
+const DEFAULT_SETTINGS = { mode: 'competitive', format: '4V4', haveBall: false };
 
 function HomeScreen() {
   const { user } = useAuth();
   const navigate = useNavigate();
+  const [showInviteModal, setShowInviteModal] = useState(false);
+  const [showModifyModal, setShowModifyModal] = useState(false);
+  const [gameSettings, setGameSettings] = useState(DEFAULT_SETTINGS);
+  const [invitedPlayers, setInvitedPlayers] = useState([]);
 
   async function handleLogout() {
     await supabase.auth.signOut();
     navigate('/');
   }
 
+  function handleInvite(friend) {
+    setInvitedPlayers(prev => [...prev, friend]);
+  }
+
+  const invitedIds = invitedPlayers.map(p => p.id);
+
   return (
-    <div className="mainBackground">
-      <div className="container">
-        <h1>Welcome!</h1>
-        <p>Logged in as: {user?.email}</p>
-        <button onClick={handleLogout}>Log Out</button>
+    <div className="home-screen">
+      <div className="home-content">
+
+        <h1 className="hero-title">
+          PLAY<br />NOW
+        </h1>
+
+        <div className="mode-section">
+          <div className="mode-row">
+            <span className="mode-label">{gameSettings.mode.toUpperCase()}</span>
+            <button className="settings-btn" aria-label="Game settings" onClick={() => setShowModifyModal(true)}>
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="3" />
+                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+              </svg>
+            </button>
+          </div>
+          <p className="mode-sub">{gameSettings.format} BASKETBALL</p>
+        </div>
+
+        <div className="player-slots">
+          {invitedPlayers.slice(0, 3).map(player => (
+            <div className="slot avatar" key={player.id} title={`@${player.username}`} />
+          ))}
+          {Array.from({ length: Math.max(0, 3 - invitedPlayers.length) }).map((_, i) => (
+            <div className="slot avatar empty" key={`empty-${i}`} aria-label="Player slot" />
+          ))}
+          <button
+            className="slot add-slot"
+            aria-label="Add player"
+            onClick={() => setShowInviteModal(true)}
+          >
+            +
+          </button>
+        </div>
+
+        <button className="search-btn">SEARCH</button>
+
       </div>
+
+      <div className="bottom-nav">
+        <button
+          className="profile-btn"
+          onClick={() => navigate('/ProfileScreen')}
+          aria-label="Profile"
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+            <circle cx="12" cy="7" r="4" />
+          </svg>
+        </button>
+      </div>
+
+      {showInviteModal && (
+        <LobbyInviteModal
+          onClose={() => setShowInviteModal(false)}
+          onInvite={handleInvite}
+          invitedIds={invitedIds}
+        />
+      )}
+
+      {showModifyModal && (
+        <ModifyGameModal
+          settings={gameSettings}
+          onClose={() => setShowModifyModal(false)}
+          onDone={updated => setGameSettings(updated)}
+        />
+      )}
     </div>
   );
 }

--- a/src/Screens/HomeScreen.js
+++ b/src/Screens/HomeScreen.js
@@ -25,6 +25,19 @@ function HomeScreen() {
     setInvitedPlayers(prev => [...prev, friend]);
   }
 
+  function handleSearch() {
+    const lobbyPayload = {
+      hostId: user.id,
+      mode: gameSettings.mode,       // 'competitive' | 'casual'
+      format: gameSettings.format,   // '1V1' | '2V2' | '3V3' | '4V4'
+      haveBall: gameSettings.haveBall,
+      partyIds: [user.id, ...invitedPlayers.map(p => p.id)],
+    };
+    // TODO: pass lobbyPayload to the matchmaking algorithm
+    // e.g. casualAlgorithm(lobbyPayload) or competitiveAlgorithm(lobbyPayload)
+    console.log('[SEARCH] lobby payload:', lobbyPayload);
+  }
+
   const invitedIds = invitedPlayers.map(p => p.id);
 
   return (
@@ -64,7 +77,7 @@ function HomeScreen() {
           </button>
         </div>
 
-        <button className="search-btn">SEARCH</button>
+        <button className="search-btn" onClick={handleSearch}>SEARCH</button>
 
       </div>
 

--- a/src/Screens/HomeScreen.js
+++ b/src/Screens/HomeScreen.js
@@ -41,7 +41,7 @@ function HomeScreen() {
   const invitedIds = invitedPlayers.map(p => p.id);
 
   return (
-    <div className="home-screen">
+    <div className="screen home-screen">
       <div className="home-content">
 
         <h1 className="hero-title">

--- a/src/components/LobbyInviteModal.css
+++ b/src/components/LobbyInviteModal.css
@@ -1,0 +1,124 @@
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--color-overlay);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--page-padding-x);
+  z-index: 100;
+}
+
+.modal-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  width: 100%;
+  max-width: 360px;
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+/* ── Header: search + close ── */
+.modal-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.search-row {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  background: var(--color-bg);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+}
+
+.search-icon {
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+.search-input {
+  flex: 1;
+  background: none;
+  border: none;
+  outline: none;
+  color: var(--color-text);
+  font-family: var(--font-family);
+  font-size: var(--text-sm);
+}
+
+.search-input::placeholder {
+  color: var(--color-text-muted);
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  color: var(--color-text);
+  font-family: var(--font-family);
+  font-size: var(--text-sm);
+  font-weight: var(--font-bold);
+  cursor: pointer;
+  padding: var(--space-1) var(--space-2);
+  flex-shrink: 0;
+}
+
+/* ── Friends list ── */
+.friends-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.friend-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.friend-row:last-child {
+  border-bottom: none;
+}
+
+.friend-name {
+  color: var(--color-text);
+  font-family: var(--font-family);
+  font-size: var(--text-sm);
+  font-weight: var(--font-bold);
+}
+
+.invite-btn {
+  background: var(--color-bg);
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--color-text);
+  font-family: var(--font-family);
+  font-size: var(--text-xs);
+  font-weight: var(--font-bold);
+  letter-spacing: 0.08em;
+  padding: var(--space-1) var(--space-3);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  min-width: 64px;
+  text-align: center;
+}
+
+.invite-btn.invited {
+  background: var(--color-accent);
+  color: #000;
+  cursor: default;
+}
+
+.modal-empty {
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  text-align: center;
+  padding: var(--space-4) 0;
+  margin: 0;
+}

--- a/src/components/LobbyInviteModal.js
+++ b/src/components/LobbyInviteModal.js
@@ -1,0 +1,101 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '../supabaseClient';
+import { useAuth } from '../context/AuthContext';
+import './LobbyInviteModal.css';
+
+// ─── Supabase integration point ──────────────────────────────────────────────
+// Replace MOCK_FRIENDS with a real fetch once you have DB access:
+//
+//   const { data, error } = await supabase
+//     .from('friends')
+//     .select('friend_id, app_user!friend_id(username)')
+//     .eq('user_id', user.id);
+//
+// Expected shape: [{ id, username }]
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MOCK_FRIENDS = [
+  { id: '1', username: 'warren' },
+  { id: '2', username: 'jake' },
+  { id: '3', username: 'nicolle' },
+  { id: '4', username: 'carson' },
+];
+
+function LobbyInviteModal({ onClose, onInvite, invitedIds = [] }) {
+  const { user } = useAuth();
+  const [friends, setFriends] = useState([]);
+  const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchFriends() {
+      setLoading(true);
+
+      // ── Swap this block for the real Supabase query when ready ──
+      // const { data, error } = await supabase
+      //   .from('friends')
+      //   .select('friend_id, app_user!friend_id(username)')
+      //   .eq('user_id', user.id);
+      // if (!error) setFriends(data.map(r => ({ id: r.friend_id, username: r.app_user.username })));
+      // ────────────────────────────────────────────────────────────
+
+      setFriends(MOCK_FRIENDS);
+      setLoading(false);
+    }
+
+    fetchFriends();
+  }, [user]);
+
+  const filtered = friends.filter(f =>
+    f.username.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-card" onClick={e => e.stopPropagation()}>
+
+        <div className="modal-header">
+          <div className="search-row">
+            <svg className="search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="11" cy="11" r="8" /><line x1="21" y1="21" x2="16.65" y2="16.65" />
+            </svg>
+            <input
+              className="search-input"
+              type="text"
+              placeholder="Search"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              autoFocus
+            />
+          </div>
+          <button className="close-btn" onClick={onClose} aria-label="Close">X</button>
+        </div>
+
+        <div className="friends-list">
+          {loading && <p className="modal-empty">Loading...</p>}
+          {!loading && filtered.length === 0 && (
+            <p className="modal-empty">No friends found</p>
+          )}
+          {!loading && filtered.map(friend => {
+            const invited = invitedIds.includes(friend.id);
+            return (
+              <div className="friend-row" key={friend.id}>
+                <span className="friend-name">@{friend.username}</span>
+                <button
+                  className={`invite-btn ${invited ? 'invited' : ''}`}
+                  onClick={() => !invited && onInvite(friend)}
+                  disabled={invited}
+                >
+                  {invited ? 'INVITED' : 'INVITE'}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+
+      </div>
+    </div>
+  );
+}
+
+export default LobbyInviteModal;

--- a/src/components/LobbyInviteModal.js
+++ b/src/components/LobbyInviteModal.js
@@ -1,25 +1,6 @@
 import { useState, useEffect } from 'react';
-import { supabase } from '../supabaseClient';
 import { useAuth } from '../context/AuthContext';
 import './LobbyInviteModal.css';
-
-// ─── Supabase integration point ──────────────────────────────────────────────
-// Replace MOCK_FRIENDS with a real fetch once you have DB access:
-//
-//   const { data, error } = await supabase
-//     .from('friends')
-//     .select('friend_id, app_user!friend_id(username)')
-//     .eq('user_id', user.id);
-//
-// Expected shape: [{ id, username }]
-// ─────────────────────────────────────────────────────────────────────────────
-
-const MOCK_FRIENDS = [
-  { id: '1', username: 'warren' },
-  { id: '2', username: 'jake' },
-  { id: '3', username: 'nicolle' },
-  { id: '4', username: 'carson' },
-];
 
 function LobbyInviteModal({ onClose, onInvite, invitedIds = [] }) {
   const { user } = useAuth();
@@ -30,16 +11,12 @@ function LobbyInviteModal({ onClose, onInvite, invitedIds = [] }) {
   useEffect(() => {
     async function fetchFriends() {
       setLoading(true);
-
-      // ── Swap this block for the real Supabase query when ready ──
+      // TODO: wire up once friends table is ready
       // const { data, error } = await supabase
       //   .from('friends')
       //   .select('friend_id, app_user!friend_id(username)')
       //   .eq('user_id', user.id);
       // if (!error) setFriends(data.map(r => ({ id: r.friend_id, username: r.app_user.username })));
-      // ────────────────────────────────────────────────────────────
-
-      setFriends(MOCK_FRIENDS);
       setLoading(false);
     }
 

--- a/src/components/ModifyGameModal.css
+++ b/src/components/ModifyGameModal.css
@@ -1,0 +1,144 @@
+.modify-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  width: 100%;
+  max-width: 360px;
+  padding: var(--space-5) var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+/* ── Header ── */
+.modify-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.modify-title {
+  font-family: var(--font-family);
+  font-size: var(--text-xl);
+  font-weight: var(--font-black);
+  color: var(--color-text);
+  letter-spacing: 0.04em;
+}
+
+.hamburger-btn {
+  background: none;
+  border: none;
+  color: var(--color-text);
+  cursor: pointer;
+  padding: var(--space-1);
+  display: flex;
+  align-items: center;
+}
+
+/* ── Mode toggle ── */
+.mode-toggle {
+  display: flex;
+  gap: var(--space-4);
+}
+
+.mode-option {
+  background: none;
+  border: none;
+  font-family: var(--font-family);
+  font-size: var(--text-sm);
+  font-weight: var(--font-black);
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: 0;
+  transition: color var(--transition-fast);
+}
+
+.mode-option.active {
+  color: var(--color-accent);
+}
+
+/* ── Format row ── */
+.format-row {
+  display: flex;
+  gap: var(--space-3);
+  align-items: center;
+}
+
+.format-btn {
+  background: none;
+  border: none;
+  font-family: var(--font-family);
+  font-size: var(--text-sm);
+  font-weight: var(--font-black);
+  letter-spacing: 0.04em;
+  color: var(--color-text);
+  cursor: pointer;
+  padding: 0;
+  transition: color var(--transition-fast);
+}
+
+.format-btn.active {
+  color: var(--color-accent);
+}
+
+.format-btn.disabled {
+  color: var(--color-disabled);
+  cursor: not-allowed;
+  text-decoration: line-through;
+}
+
+/* ── Footer ── */
+.modify-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.have-ball-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.have-ball-label {
+  font-family: var(--font-family);
+  font-size: var(--text-sm);
+  font-weight: var(--font-black);
+  color: var(--color-text);
+  letter-spacing: 0.06em;
+}
+
+.have-ball-toggle {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-sm);
+  border: 2px solid var(--color-text-muted);
+  background: none;
+  color: var(--color-text);
+  font-family: var(--font-family);
+  font-size: var(--text-xs);
+  font-weight: var(--font-black);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.have-ball-toggle.on {
+  border-color: var(--color-accent);
+  background: var(--color-accent);
+  color: #000;
+}
+
+.done-btn {
+  background: none;
+  border: none;
+  font-family: var(--font-family);
+  font-size: var(--text-sm);
+  font-weight: var(--font-black);
+  letter-spacing: 0.06em;
+  color: var(--color-text);
+  cursor: pointer;
+  padding: 0;
+}

--- a/src/components/ModifyGameModal.js
+++ b/src/components/ModifyGameModal.js
@@ -1,0 +1,80 @@
+import './ModifyGameModal.css';
+
+const FORMATS = ['1V1', '2V2', '3V3', '4V4', '5V5'];
+
+function ModifyGameModal({ settings, onClose, onDone }) {
+  const { mode, format, haveBall } = settings;
+
+  function update(key, value) {
+    onDone({ ...settings, [key]: value });
+  }
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modify-card" onClick={e => e.stopPropagation()}>
+
+        <div className="modify-header">
+          <span className="modify-title">BASKETBALL</span>
+          <button className="hamburger-btn" aria-label="More options">
+            <svg width="18" height="14" viewBox="0 0 18 14" fill="currentColor">
+              <rect width="18" height="2" rx="1" />
+              <rect y="6" width="18" height="2" rx="1" />
+              <rect y="12" width="18" height="2" rx="1" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="mode-toggle">
+          <button
+            className={`mode-option ${mode === 'competitive' ? 'active' : ''}`}
+            onClick={() => update('mode', 'competitive')}
+          >
+            COMPETITIVE
+          </button>
+          <button
+            className={`mode-option ${mode === 'casual' ? 'active' : ''}`}
+            onClick={() => update('mode', 'casual')}
+          >
+            CASUAL
+          </button>
+        </div>
+
+        <div className="format-row">
+          {FORMATS.map(f => {
+            const disabled = f === '5V5';
+            const active = format === f;
+            return (
+              <button
+                key={f}
+                className={`format-btn ${active ? 'active' : ''} ${disabled ? 'disabled' : ''}`}
+                onClick={() => !disabled && update('format', f)}
+                disabled={disabled}
+                aria-label={disabled ? `${f} — coming soon` : f}
+              >
+                {f}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="modify-footer">
+          <div className="have-ball-row">
+            <span className="have-ball-label">HAVE BALL</span>
+            <button
+              className={`have-ball-toggle ${haveBall ? 'on' : ''}`}
+              onClick={() => update('haveBall', !haveBall)}
+              aria-pressed={haveBall}
+              aria-label="Have ball"
+            >
+              {haveBall ? '✓' : 'X'}
+            </button>
+          </div>
+          <button className="done-btn" onClick={onClose}>DONE</button>
+        </div>
+
+      </div>
+    </div>
+  );
+}
+
+export default ModifyGameModal;

--- a/src/components/ModifyGameModal.js
+++ b/src/components/ModifyGameModal.js
@@ -15,13 +15,6 @@ function ModifyGameModal({ settings, onClose, onDone }) {
 
         <div className="modify-header">
           <span className="modify-title">BASKETBALL</span>
-          <button className="hamburger-btn" aria-label="More options">
-            <svg width="18" height="14" viewBox="0 0 18 14" fill="currentColor">
-              <rect width="18" height="2" rx="1" />
-              <rect y="6" width="18" height="2" rx="1" />
-              <rect y="12" width="18" height="2" rx="1" />
-            </svg>
-          </button>
         </div>
 
         <div className="mode-toggle">

--- a/src/tokens.css
+++ b/src/tokens.css
@@ -12,6 +12,8 @@
   --color-text:         #FFFFFF;   /* white — body copy */
   --color-text-muted:   rgba(255, 255, 255, 0.5);  /* dimmed text */
   --color-icon:         #AAAAAA;   /* muted icon / placeholder circles */
+  --color-reporter:     #E63946;   /* red — game result reporter / captain indicator */
+  --color-ball:         #9B5DE5;   /* purple — ball-bringer indicator */
   --color-modal-bg:     #FFFFFF;   /* white — modal card background */
   --color-modal-text:   #000000;   /* black — text inside modal cards */
   --color-overlay:      rgba(0, 0, 0, 0.6);  /* dim behind modals */
@@ -26,6 +28,7 @@
   --text-lg:    1.25rem;   /* 20px */
   --text-xl:    1.5rem;    /* 24px */
   --text-2xl:   2rem;      /* 32px */
+  --text-3xl:   3rem;      /* 48px — large display numbers e.g. game time */
   --text-hero:  clamp(5rem, 22vw, 7rem);  /* "PLAY NOW" headline — scales with phone width */
 
   --font-normal: 400;


### PR DESCRIPTION
## Summary
- Distributes content vertically across the full screen so there's no dead space at the bottom
- Empty party slots render as dashed outlines instead of filled circles (no one in party by default)
- Aligns player slots and + button on the same row
- Adds profile icon to bottom right linking to the profile screen
- Removes hamburger menu from game settings modal
- SEARCH button now builds a `lobbyPayload` (hostId, mode, format, haveBall, partyIds) ready for the casual/competitive matchmaking algorithm to consume
- Clears mock friends from the invite modal - Supabase query is stubbed with a TODO for when the friends table is ready

Closes #3