### PR TITLE
Rating screen (skill + sportsmanship) and shared file sync

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,8 +4,6 @@ import SplashScreen from './Screens/SplashScreen';
 import LoginScreen from './Screens/LoginScreen';
 import SignUpScreen from './Screens/SignUpScreen';
 import HomeScreen from './Screens/HomeScreen';
-import ProfileScreen from './Screens/ProfileScreen';
-import GameDetailsScreen from './Screens/GameDetailsScreen';
 import RatingScreen from './Screens/RatingScreen';
 import ProtectedRoute from './components/ProtectedRoute';
 
@@ -18,22 +16,6 @@ const router = createBrowserRouter([
     element: (
       <ProtectedRoute>
         <HomeScreen />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/ProfileScreen',
-    element: (
-      <ProtectedRoute>
-        <ProfileScreen />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/GameDetailsScreen',
-    element: (
-      <ProtectedRoute>
-        <GameDetailsScreen />
       </ProtectedRoute>
     ),
   },

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,9 @@ import SplashScreen from './Screens/SplashScreen';
 import LoginScreen from './Screens/LoginScreen';
 import SignUpScreen from './Screens/SignUpScreen';
 import HomeScreen from './Screens/HomeScreen';
+import ProfileScreen from './Screens/ProfileScreen';
+import GameDetailsScreen from './Screens/GameDetailsScreen';
+import RatingScreen from './Screens/RatingScreen';
 import ProtectedRoute from './components/ProtectedRoute';
 
 const router = createBrowserRouter([
@@ -15,6 +18,30 @@ const router = createBrowserRouter([
     element: (
       <ProtectedRoute>
         <HomeScreen />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/ProfileScreen',
+    element: (
+      <ProtectedRoute>
+        <ProfileScreen />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/GameDetailsScreen',
+    element: (
+      <ProtectedRoute>
+        <GameDetailsScreen />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/RatingScreen',
+    element: (
+      <ProtectedRoute>
+        <RatingScreen />
       </ProtectedRoute>
     ),
   },

--- a/src/Screens/RatingScreen.css
+++ b/src/Screens/RatingScreen.css
@@ -1,0 +1,92 @@
+.rating-screen {
+  justify-content: space-between;
+  align-items: center;
+  text-align: center;
+  height: 100svh;
+  overflow: hidden;
+  padding-bottom: var(--space-12);
+}
+
+/* ── Header ── */
+.rating-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1);
+  padding-top: var(--space-10);
+  width: 100%;
+}
+
+.rating-title {
+  font-size: var(--text-hero);
+  font-weight: var(--font-black);
+  line-height: 0.88;
+  letter-spacing: -0.02em;
+  color: var(--color-text);
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.rating-subtitle {
+  font-size: var(--text-xl);
+  font-weight: var(--font-black);
+  color: var(--color-text);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0;
+}
+
+/* ── Player avatar ── */
+.rating-avatar {
+  width: 120px;
+  height: 120px;
+  border-radius: var(--radius-full);
+  background: var(--color-icon);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.rating-avatar-name {
+  font-size: var(--text-base);
+  font-weight: var(--font-black);
+  color: var(--color-text);
+  letter-spacing: 0.05em;
+}
+
+/* ── Rating dots ── */
+.rating-dots {
+  display: flex;
+  gap: var(--space-4);
+  justify-content: center;
+}
+
+.rating-dot {
+  width: 52px;
+  height: 52px;
+  border-radius: var(--radius-full);
+  background: var(--color-icon);
+  border: none;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  padding: 0;
+  margin: 0;
+  flex-shrink: 0;
+}
+
+.rating-dot.active {
+  background: var(--color-reporter);
+}
+
+/* ── Skip ── */
+.rating-skip {
+  background: none;
+  border: none;
+  color: var(--color-text);
+  font-family: var(--font-family);
+  font-size: var(--text-xl);
+  font-weight: var(--font-black);
+  letter-spacing: 0.12em;
+  cursor: pointer;
+  padding: 0;
+}

--- a/src/Screens/RatingScreen.js
+++ b/src/Screens/RatingScreen.js
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import './RatingScreen.css';
+
+// ─── Supabase integration point ───────────────────────────────────────────────
+// Receives rating queue via React Router location.state from GameDetailsScreen
+// once the game is completed:
+//
+//   navigate('/RatingScreen', { state: { queue } });
+//
+// Queue shape:
+//   [
+//     { id, username, type: 'skill' },          // teammates — rate skill
+//     { id, username, type: 'sportsmanship' },  // opponents — rate sportsmanship
+//   ]
+//
+// On completion, submit ratings to Supabase:
+//   for each rated player:
+//     await supabase.from('ratings')
+//       .upsert({ user_id: player.id, [type]: rating, rated_by: currentUser.id });
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MOCK_QUEUE = [
+  { id: '1', username: 'TOM',    type: 'skill' },
+  { id: '2', username: 'SARAH',  type: 'skill' },
+  { id: '3', username: 'JIM',    type: 'sportsmanship' },
+  { id: '4', username: 'ALEX',   type: 'sportsmanship' },
+];
+
+const DOTS = 5;
+
+function RatingScreen() {
+  const { state } = useLocation();
+  const navigate = useNavigate();
+  const queue = state?.queue ?? MOCK_QUEUE;
+
+  const [index, setIndex]   = useState(0);
+  const [selected, setSelected] = useState(0);
+  const [ratings, setRatings]   = useState({});
+
+  const current = queue[index];
+
+  function advance(rating) {
+    const next = { ...ratings };
+    if (rating) next[current.id] = rating;
+    setRatings(next);
+
+    if (index < queue.length - 1) {
+      setIndex(i => i + 1);
+      setSelected(0);
+    } else {
+      // TODO: submit `next` to Supabase, then navigate back
+      console.log('[RATINGS] submitted:', next);
+      navigate('/HomeScreen');
+    }
+  }
+
+  function handleDot(dot) {
+    setSelected(dot);
+    setTimeout(() => advance(dot), 300);
+  }
+
+  function handleSkip() {
+    advance(null);
+  }
+
+  const isSkill = current.type === 'skill';
+
+  return (
+    <div className="screen rating-screen">
+
+      <div className="rating-header">
+        <h1 className="rating-title">RATE</h1>
+        <p className="rating-subtitle">{isSkill ? 'SKILL LEVEL' : 'SPORTSMANSHIP'}</p>
+      </div>
+
+      <div className="rating-avatar">
+        <span className="rating-avatar-name">{current.username}</span>
+      </div>
+
+      <div className="rating-dots">
+        {Array.from({ length: DOTS }).map((_, i) => {
+          const dot = i + 1;
+          return (
+            <button
+              key={dot}
+              className={`rating-dot ${selected >= dot ? 'active' : ''}`}
+              onClick={() => handleDot(dot)}
+              aria-label={`Rate ${dot} out of ${DOTS}`}
+            />
+          );
+        })}
+      </div>
+
+      <button className="rating-skip" onClick={handleSkip}>SKIP</button>
+
+    </div>
+  );
+}
+
+export default RatingScreen;

--- a/src/tokens.css
+++ b/src/tokens.css
@@ -12,6 +12,8 @@
   --color-text:         #FFFFFF;   /* white — body copy */
   --color-text-muted:   rgba(255, 255, 255, 0.5);  /* dimmed text */
   --color-icon:         #AAAAAA;   /* muted icon / placeholder circles */
+  --color-reporter:     #E63946;   /* red — game result reporter / captain indicator */
+  --color-ball:         #9B5DE5;   /* purple — ball-bringer indicator */
   --color-modal-bg:     #FFFFFF;   /* white — modal card background */
   --color-modal-text:   #000000;   /* black — text inside modal cards */
   --color-overlay:      rgba(0, 0, 0, 0.6);  /* dim behind modals */
@@ -26,6 +28,7 @@
   --text-lg:    1.25rem;   /* 20px */
   --text-xl:    1.5rem;    /* 24px */
   --text-2xl:   2rem;      /* 32px */
+  --text-3xl:   3rem;      /* 48px — large display numbers e.g. game time */
   --text-hero:  clamp(5rem, 22vw, 7rem);  /* "PLAY NOW" headline — scales with phone width */
 
   --font-normal: 400;


### PR DESCRIPTION
## Summary
- Post-game rating screen cycles through players one at a time
- Skill rating for teammates, sportsmanship rating for opponents
- 5-dot cumulative rating UI — tap a dot to rate, auto-advances to next player
- SKIP button skips current player without rating
- Ratings collected into a map and logged to console — ready for Supabase upsert when ratings table is confirmed
- Receives player queue via React Router location.state from the game flow
- Syncs App.js with all routes from other open branches (ProfileScreen, GameDetailsScreen, RatingScreen)
- Syncs tokens.css with --color-reporter, --color-ball, --text-3xl added in feat/game-details

## Test plan
- [ ] Navigate to /RatingScreen — shows RATE SKILL LEVEL with TOM
- [ ] Tap a dot — turns red cumulatively, auto-advances after 300ms
- [ ] SKIP advances without rating
- [ ] Cycles through all 4 mock players (2 skill, 2 sportsmanship)
- [ ] After last player, logs ratings object to console and navigates to /HomeScreen

Closes #13