### PR TITLE
Wire up LandingPage route (#29 follow-up)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { AuthProvider } from './context/AuthContext';
 import SplashScreen from './Screens/SplashScreen';
+import LandingPage from './Screens/LandingPage';
 import LoginScreen from './Screens/LoginScreen';
 import ProfileCreationScreen from './Screens/ProfileCreationScreen';
 import HomeScreen from './Screens/HomeScreen';
@@ -11,6 +12,7 @@ import ProtectedRoute from './components/ProtectedRoute';
 
 const router = createBrowserRouter([
   { path: '/', element: <SplashScreen /> },
+  { path: '/LandingPage', element: <LandingPage /> },
   { path: '/LoginScreen', element: <LoginScreen /> },
   { path: '/ProfileCreationScreen', element: <ProfileCreationScreen /> },
   {

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,5 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { AuthProvider } from './context/AuthContext';
-import SplashScreen from './Screens/SplashScreen';
 import LandingPage from './Screens/LandingPage';
 import LoginScreen from './Screens/LoginScreen';
 import ProfileCreationScreen from './Screens/ProfileCreationScreen';
@@ -11,8 +10,7 @@ import RatingScreen from './Screens/RatingScreen';
 import ProtectedRoute from './components/ProtectedRoute';
 
 const router = createBrowserRouter([
-  { path: '/', element: <SplashScreen /> },
-  { path: '/LandingPage', element: <LandingPage /> },
+  { path: '/', element: <LandingPage /> },
   { path: '/LoginScreen', element: <LoginScreen /> },
   { path: '/ProfileCreationScreen', element: <ProfileCreationScreen /> },
   {


### PR DESCRIPTION
## Summary
- Adds `/LandingPage` route in `App.js`, pointing to `LandingPage` from PR #29.
- navdeyev05's landing page (Welcome → About → Features, scroll-anchored) was merged to dev in PR #29 but left disconnected ("Note: the landing page is not connected to App.js yet"). This finishes that step.

## Test plan
- [ ] `npm start`, visit `/LandingPage`, confirm the page renders with Navigation bar + three sections.
- [ ] Click the nav links (Welcome / About Pickup / Features) and confirm smooth-scroll between sections works.
- [ ] Vercel preview deploys green.

## Note
This adds a separate route. If for the demo you'd like `/` to land on `LandingPage` instead of `SplashScreen` (since `LandingPage` already embeds `SplashScreen` as its first section), that's a one-line swap — say the word.