### PR TITLE
Fix global svg rule breaking all SVG icons

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -310,7 +310,7 @@ button {
 	height: 450px;
 }
 
-svg{
+.circle-container svg{
 	position: absolute;
 	top: 0;
 	left: 0;


### PR DESCRIPTION
## Bug
`styles.css` contained a bare `svg { position: absolute; width: 100%; height: 100% }` rule that applied to every SVG in the app, blowing up icons (gear, profile, home, etc.) to full screen size.

## Fix
Scoped the rule to `.circle-container svg` which is the only element it was intended for.