### PR TITLE
Fix 5V5 strikethrough in game settings modal

### DIFF
--- a/src/components/ModifyGameModal.css
+++ b/src/components/ModifyGameModal.css
@@ -84,7 +84,6 @@
 .format-btn.disabled {
   color: var(--color-disabled);
   cursor: not-allowed;
-  text-decoration: line-through;
 }
 
 /* ── Footer ── */


### PR DESCRIPTION
5V5 was showing with a line-through, removed it - now just dims with color-disabled like the other unavailable states.