### PR TITLE
Fix profile screen display name

### DIFF
--- a/src/Screens/ProfileScreen.js
+++ b/src/Screens/ProfileScreen.js
@@ -60,7 +60,12 @@ function ProfileScreen() {
 
   useEffect(() => {
     if (!user) return;
-    // TODO: wire up Supabase fetches when tables are ready
+    supabase
+      .from('app_user')
+      .select('username, display_name')
+      .eq('user_id', user.id)
+      .single()
+      .then(({ data }) => { if (data) setProfile(data); });
   }, [user]);
 
   function toggle(section) {
@@ -72,7 +77,7 @@ function ProfileScreen() {
     navigate('/');
   }
 
-  const username = profile?.username ?? user?.email?.split('@')[0] ?? '';
+  const username = profile?.display_name || profile?.username || user?.email?.split('@')[0] || '';
   const onlineFriends = friends?.filter(f => f.is_online).length ?? 0;
 
   return (


### PR DESCRIPTION
## Summary
- Fetches `display_name` and `username` from `app_user` table on profile load
- Profile header now shows the display name the user entered at registration
- Falls back to username, then email prefix if display_name is not set
