### PR TITLE
Fix Inter font weight inconsistency across browsers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Document</title>
-  <link href='https://fonts.googleapis.com/css?family=Inter' rel='stylesheet'>
+  <link href='https://fonts.googleapis.com/css2?family=Inter:wght@400;700;900&display=swap' rel='stylesheet'>
 </head>
 <body>
 	


### PR DESCRIPTION
## Summary
- Updated Google Fonts URL to explicitly request Inter weights 400, 700, and 900
- Previous URL only fetched weight 400. 
