### PR TITLE
Set auth_id on app_user insert during sign-up

### DIFF
--- a/src/Screens/ProfileCreationScreen.js
+++ b/src/Screens/ProfileCreationScreen.js
@@ -88,7 +88,7 @@ function ProfileCreationScreen() {
     setIsLoading(true);
 
     // Create Supabase Auth account
-    const { error: authError } = await supabase.auth.signUp({
+    const { data: authData, error: authError } = await supabase.auth.signUp({
       email,
       password,
     });
@@ -99,10 +99,17 @@ function ProfileCreationScreen() {
       return;
     }
 
-    // Insert app_user record
+    if (!authData?.user?.id) {
+      setError('Sign-up succeeded but no user was returned. If email confirmation is enabled in Supabase, finish creating your profile after clicking the confirmation link.');
+      setIsLoading(false);
+      return;
+    }
+
+    // Insert app_user record, linking back to the auth.users row via auth_id
     const { error: insertError } = await supabase
       .from('app_user')
       .insert({
+        auth_id: authData.user.id,
         username: username.trim(),
         email,
         display_name: displayName.trim() || null,


### PR DESCRIPTION
## Summary
- `ProfileCreationScreen` was calling `supabase.auth.signUp()` but discarding the response `data`, then inserting an `app_user` row without `auth_id`.
- Whether `auth_id` got populated depended entirely on a DB default/trigger (`auth.uid()`) that only fires when a session is active at insert time — so any sign-up that didn't establish a session immediately (e.g. email confirmation enabled) ended up with `auth_id` NULL.
- Now: capture `data` from `signUp`, fail loudly if no user is returned, and pass `auth_id: authData.user.id` explicitly on the insert.

## Why this matters
`auth_id` is the link between Supabase Auth (`auth.users`) and the app's profile table. A user with `auth_id` NULL can't be looked up by their JWT — they sign in fine but `app_user WHERE auth_id = auth.uid()` returns nothing, so any feature that loads the user's profile (display name, friends, etc.) silently fails for them.

## Test plan
- [ ] Sign up a new user end-to-end and confirm an `app_user` row exists with `auth_id` populated.
- [ ] Check the existing data: `SELECT COUNT(*) AS without_auth_id FROM app_user WHERE auth_id IS NULL;` — anyone returned here is a pre-existing user that will need their `auth_id` backfilled (separate cleanup).
- [ ] Confirm Vercel preview builds green.

## Follow-ups (not in this PR)
- Backfill `auth_id` for existing rows that have it NULL (match by `app_user.email = auth.users.email`).
- Make `app_user.auth_id` `NOT NULL UNIQUE` with a FK to `auth.users(id) ON DELETE CASCADE` once the backfill is done.