### PR TITLE
Wire up LobbyInviteModal and fix ManageFriendsModal friend/invite flow

### DIFF
--- a/src/Screens/ProfileScreen.js
+++ b/src/Screens/ProfileScreen.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { supabase } from '../supabaseClient';
@@ -57,6 +57,20 @@ function ProfileScreen() {
   const [friends, setFriends] = useState(null);
   const [ratings, setRatings] = useState(null);
   const [teams, setTeams] = useState(null);
+  const channelRef = useRef(null);
+
+  async function loadFriends(uid) {
+    const { data: rows } = await supabase
+      .from('friendship')
+      .select('friendship_id, requester_id, receiver_id, requester:app_user!friendship_requester_id_fkey(user_id, username), receiver:app_user!friendship_receiver_id_fkey(user_id, username)')
+      .or(`requester_id.eq.${uid},receiver_id.eq.${uid}`)
+      .eq('status', 'accepted');
+    if (!rows) return;
+    setFriends(rows.map(r => {
+      const friend = r.requester_id === uid ? r.receiver : r.requester;
+      return { id: r.friendship_id, username: friend?.username };
+    }));
+  }
 
   useEffect(() => {
     if (!user) return;
@@ -65,7 +79,23 @@ function ProfileScreen() {
       .select('username, display_name, user_id')
       .eq('auth_id', user.id)
       .single()
-      .then(({ data }) => { if (data) setProfile(data); });
+      .then(({ data }) => {
+        if (!data) return;
+        setProfile(data);
+        loadFriends(data.user_id);
+
+        if (channelRef.current) supabase.removeChannel(channelRef.current);
+        channelRef.current = supabase
+          .channel(`friendship-${data.user_id}`)
+          .on('postgres_changes', { event: '*', schema: 'public', table: 'friendship' }, () => {
+            loadFriends(data.user_id);
+          })
+          .subscribe();
+      });
+
+    return () => {
+      if (channelRef.current) supabase.removeChannel(channelRef.current);
+    };
   }, [user]);
 
   function toggle(section) {
@@ -119,16 +149,14 @@ function ProfileScreen() {
         <div className="profile-section" onClick={() => toggle('friends')}>
           <div className="profile-section-row">
             <span className="profile-section-label">FRIENDS</span>
-            <span className="profile-section-value">
-              {friends && onlineFriends > 0 ? `${onlineFriends} ONLINE` : ''}
-            </span>
           </div>
           {open === 'friends' && (
             <div className="profile-section-body">
-              {friends?.map(f => (
-                <span key={f.id} className="profile-friend-name">
-                  @{f.username}{f.is_online ? '*' : ''}
-                </span>
+              {friends && friends.length === 0 && (
+                <span className="profile-friend-name">No friends yet</span>
+              )}
+              {friends?.slice(0, 4).map(f => (
+                <span key={f.id} className="profile-friend-name">@{f.username}</span>
               ))}
               <button className="profile-action-link" onClick={e => { e.stopPropagation(); setShowFriendsModal(true); }}>
                 MANAGE
@@ -187,7 +215,7 @@ function ProfileScreen() {
       <button className="profile-logout" onClick={handleLogout}>LOGOUT</button>
 
       {showFriendsModal && (
-        <ManageFriendsModal onClose={() => setShowFriendsModal(false)} />
+        <ManageFriendsModal onClose={() => setShowFriendsModal(false)} myUserId={profile?.user_id} onFriendsChange={() => loadFriends(profile?.user_id)} />
       )}
 
       {showTeamsModal && (

--- a/src/components/LobbyInviteModal.js
+++ b/src/components/LobbyInviteModal.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
+import { supabase } from '../supabaseClient';
 import './LobbyInviteModal.css';
 
 function LobbyInviteModal({ onClose, onInvite, invitedIds = [] }) {
@@ -9,14 +10,32 @@ function LobbyInviteModal({ onClose, onInvite, invitedIds = [] }) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    if (!user) return;
+
     async function fetchFriends() {
       setLoading(true);
-      // TODO: wire up once friends table is ready
-      // const { data, error } = await supabase
-      //   .from('friends')
-      //   .select('friend_id, app_user!friend_id(username)')
-      //   .eq('user_id', user.id);
-      // if (!error) setFriends(data.map(r => ({ id: r.friend_id, username: r.app_user.username })));
+
+      const { data: appUser } = await supabase
+        .from('app_user')
+        .select('user_id')
+        .eq('auth_id', user.id)
+        .single();
+
+      if (!appUser) { setLoading(false); return; }
+
+      const { data } = await supabase
+        .from('friendship')
+        .select('requester_id, receiver_id, requester:app_user!friendship_requester_id_fkey(user_id, username), receiver:app_user!friendship_receiver_id_fkey(user_id, username)')
+        .or(`requester_id.eq.${appUser.user_id},receiver_id.eq.${appUser.user_id}`)
+        .eq('status', 'accepted');
+
+      if (data) {
+        setFriends(data.map(r => {
+          const friend = r.requester_id === appUser.user_id ? r.receiver : r.requester;
+          return { id: friend?.user_id, username: friend?.username };
+        }));
+      }
+
       setLoading(false);
     }
 

--- a/src/components/ManageFriendsModal.js
+++ b/src/components/ManageFriendsModal.js
@@ -3,9 +3,9 @@ import { useAuth } from '../context/AuthContext';
 import { supabase } from '../supabaseClient';
 import './ManageFriendsModal.css';
 
-function ManageFriendsModal({ onClose }) {
+function ManageFriendsModal({ onClose, myUserId: myUserIdProp, onFriendsChange }) {
   const { user } = useAuth();
-  const [myUserId, setMyUserId] = useState(null);
+  const [myUserId, setMyUserId] = useState(myUserIdProp ?? null);
   const [friends, setFriends] = useState([]);
   const [pending, setPending] = useState([]);
   const [adding, setAdding] = useState(false);
@@ -16,22 +16,22 @@ function ManageFriendsModal({ onClose }) {
     const [friendsRes, pendingRes] = await Promise.all([
       supabase
         .from('friendship')
-        .select('friendship_id, requester_id, receiver_id, app_user!friendship_receiver_id_fkey(user_id, username), app_user!friendship_requester_id_fkey(user_id, username)')
+        .select('friendship_id, requester_id, receiver_id, requester:app_user!friendship_requester_id_fkey(user_id, username), receiver:app_user!friendship_receiver_id_fkey(user_id, username)')
         .or(`requester_id.eq.${userId},receiver_id.eq.${userId}`)
         .eq('status', 'accepted'),
       supabase
         .from('friendship')
-        .select('friendship_id, requester_id, app_user!friendship_requester_id_fkey(username)')
+        .select('friendship_id, requester_id, requester:app_user!friendship_requester_id_fkey(username)')
         .eq('receiver_id', userId)
         .eq('status', 'pending'),
     ]);
 
+    console.log('[Friends] friendsRes data:', friendsRes.data, 'error:', friendsRes.error);
+    console.log('[Friends] pendingRes data:', pendingRes.data, 'error:', pendingRes.error);
+
     if (friendsRes.data) {
       setFriends(friendsRes.data.map(r => {
-        const isRequester = r.requester_id === userId;
-        const friend = isRequester
-          ? r['app_user!friendship_receiver_id_fkey']
-          : r['app_user!friendship_requester_id_fkey'];
+        const friend = r.requester_id === userId ? r.receiver : r.requester;
         return { id: r.friendship_id, friendUserId: friend?.user_id, username: friend?.username };
       }));
     }
@@ -40,13 +40,17 @@ function ManageFriendsModal({ onClose }) {
       setPending(pendingRes.data.map(r => ({
         id: r.friendship_id,
         senderId: r.requester_id,
-        username: r['app_user!friendship_requester_id_fkey']?.username,
+        username: r.requester?.username,
       })));
     }
   }, []);
 
   useEffect(() => {
     if (!user) return;
+    if (myUserIdProp) {
+      loadData(myUserIdProp);
+      return;
+    }
     supabase
       .from('app_user')
       .select('user_id')
@@ -58,11 +62,15 @@ function ManageFriendsModal({ onClose }) {
           loadData(data.user_id);
         }
       });
-  }, [user, loadData]);
+  }, [user, myUserIdProp, loadData]);
 
   async function handleDelete(friendshipId) {
-    await supabase.from('friendship').delete().eq('friendship_id', friendshipId);
-    setFriends(prev => prev.filter(f => f.id !== friendshipId));
+    const { error } = await supabase.from('friendship').delete().eq('friendship_id', friendshipId);
+    console.log('[Friends] delete error:', error);
+    if (!error) {
+      setFriends(prev => prev.filter(f => f.id !== friendshipId));
+      onFriendsChange?.();
+    }
   }
 
   async function handleSendRequest() {
@@ -85,6 +93,11 @@ function ManageFriendsModal({ onClose }) {
       return;
     }
 
+    if (friends.some(f => f.friendUserId === target.user_id)) {
+      setAddError('You are already friends.');
+      return;
+    }
+
     const { error } = await supabase
       .from('friendship')
       .insert({ requester_id: myUserId, receiver_id: target.user_id, status: 'pending' });
@@ -99,12 +112,14 @@ function ManageFriendsModal({ onClose }) {
   }
 
   async function handleAccept(requestId, senderId) {
-    await supabase
+    const { error } = await supabase
       .from('friendship')
       .update({ status: 'accepted' })
       .eq('friendship_id', requestId);
+    console.log('[Friends] accept error:', error);
     setPending(prev => prev.filter(p => p.id !== requestId));
     loadData(myUserId);
+    onFriendsChange?.();
   }
 
   async function handleDecline(requestId) {


### PR DESCRIPTION
- LobbyInviteModal now fetches accepted friends from friendship table
- Fix dual FK join error by using PostgREST aliases (requester/receiver)
- Add duplicate friend request guard using local friends state
- ProfileScreen loads friends on mount and passes user_id to modal
- Add Realtime subscription on friendship table for live updates
- onFriendsChange callback keeps profile friends list in sync after modal mutations