### PR TITLE
Party invites + friends fixes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider, Outlet } from 'react-router-dom';
 import { AuthProvider } from './context/AuthContext';
 import LandingPage from './Screens/LandingPage';
 import LoginScreen from './Screens/LoginScreen';
@@ -9,50 +9,67 @@ import GameDetailsScreen from './Screens/GameDetailsScreen';
 import ProfileScreen from './Screens/ProfileScreen';
 import RatingScreen from './Screens/RatingScreen';
 import ProtectedRoute from './components/ProtectedRoute';
+import PartyInviteListener from './components/PartyInviteListener';
+
+// Root layout: renders the active route plus the app-wide party-invite popup,
+// so an incoming party invite can appear on any screen.
+function RootLayout() {
+  return (
+    <>
+      <PartyInviteListener />
+      <Outlet />
+    </>
+  );
+}
 
 const router = createBrowserRouter([
-  { path: '/', element: <LandingPage /> },
-  { path: '/LoginScreen', element: <LoginScreen /> },
-  { path: '/ProfileCreationScreen', element: <ProfileCreationScreen /> },
   {
-    path: '/HomeScreen',
-    element: (
-      <ProtectedRoute>
-        <HomeScreen />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/FindingGameScreen',
-    element: (
-      <ProtectedRoute>
-        <FindingGameScreen />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/GameDetailsScreen',
-    element: (
-      <ProtectedRoute>
-        <GameDetailsScreen />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/ProfileScreen',
-    element: (
-      <ProtectedRoute>
-        <ProfileScreen />
-      </ProtectedRoute>
-    ),
-  },
-  {
-    path: '/RatingScreen',
-    element: (
-      <ProtectedRoute>
-        <RatingScreen />
-      </ProtectedRoute>
-    ),
+    element: <RootLayout />,
+    children: [
+      { path: '/', element: <LandingPage /> },
+      { path: '/LoginScreen', element: <LoginScreen /> },
+      { path: '/ProfileCreationScreen', element: <ProfileCreationScreen /> },
+      {
+        path: '/HomeScreen',
+        element: (
+          <ProtectedRoute>
+            <HomeScreen />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: '/FindingGameScreen',
+        element: (
+          <ProtectedRoute>
+            <FindingGameScreen />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: '/GameDetailsScreen',
+        element: (
+          <ProtectedRoute>
+            <GameDetailsScreen />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: '/ProfileScreen',
+        element: (
+          <ProtectedRoute>
+            <ProfileScreen />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: '/RatingScreen',
+        element: (
+          <ProtectedRoute>
+            <RatingScreen />
+          </ProtectedRoute>
+        ),
+      },
+    ],
   },
 ]);
 

--- a/src/Screens/FindingGameScreen.js
+++ b/src/Screens/FindingGameScreen.js
@@ -65,7 +65,7 @@ function FindingGameScreen() {
     })();
 
     return () => { cancelled = true; if (channel) supabase.removeChannel(channel); };
-  }, [user, haveBall]);
+  }, [user?.id, haveBall]);
 
   // ── Stage 2: watch my game's roster (with usernames) + readiness ──
   useEffect(() => {

--- a/src/Screens/HomeScreen.js
+++ b/src/Screens/HomeScreen.js
@@ -69,6 +69,14 @@ function HomeScreen() {
         .select('user_id, app_user(username, display_name)')
         .eq('party_id', partyId);
       if (cancelled || !data) return;
+      // if I'm no longer in this party (I left, was removed, or it disbanded), reset
+      if (!data.some(m => m.user_id === myUserId)) {
+        setPartyId(null);
+        setIsLeader(false);
+        setPartyMembers([]);
+        setInvitedPlayers([]);
+        return;
+      }
       setPartyMembers(data.map(m => ({
         user_id: m.user_id,
         name: m.app_user?.display_name || m.app_user?.username || null,
@@ -110,6 +118,24 @@ function HomeScreen() {
       .insert({ party_id: pid, inviter_id: myUserId, invitee_id: friend.id, status: 'pending' });
     if (invErr) { alert('Could not send invite: ' + invErr.message); return; }
     setInvitedPlayers(prev => [...prev, friend]);
+  }
+
+  // Leave the current party. A member just removes themselves; the leader disbands
+  // the whole party (clears invites + all members + marks it disbanded), which the
+  // other members pick up in realtime (their party_member row disappears).
+  async function handleLeaveParty() {
+    if (myUserId == null || partyId == null) return;
+    if (isLeader) {
+      await supabase.from('party_invite').delete().eq('party_id', partyId);
+      await supabase.from('party_member').delete().eq('party_id', partyId);
+      await supabase.from('party').update({ status: 'disbanded' }).eq('party_id', partyId);
+    } else {
+      await supabase.from('party_member').delete().eq('party_id', partyId).eq('user_id', myUserId);
+    }
+    setPartyId(null);
+    setIsLeader(false);
+    setPartyMembers([]);
+    setInvitedPlayers([]);
   }
 
   // Queue flow (solo or party leader): get my location -> queue myself (with the
@@ -219,6 +245,19 @@ function HomeScreen() {
         <button className="search-btn" onClick={handleSearch} disabled={searching || !canSearch}>
           {!canSearch ? 'WAITING FOR LEADER…' : searching ? 'SEARCHING…' : 'SEARCH'}
         </button>
+
+        {partyId != null && (
+          <button
+            onClick={handleLeaveParty}
+            style={{
+              background: 'none', border: 'none', color: 'var(--color-text-muted)',
+              fontFamily: 'var(--font-family)', fontWeight: 'var(--font-bold)',
+              letterSpacing: '0.08em', cursor: 'pointer', marginTop: 'var(--space-3)',
+            }}
+          >
+            {isLeader ? 'DISBAND PARTY' : 'LEAVE PARTY'}
+          </button>
+        )}
 
       </div>
 

--- a/src/Screens/HomeScreen.js
+++ b/src/Screens/HomeScreen.js
@@ -33,7 +33,7 @@ function HomeScreen() {
     supabase.from('app_user').select('user_id').eq('auth_id', user.id).maybeSingle()
       .then(({ data }) => { if (!cancelled && data) setMyUserId(data.user_id); });
     return () => { cancelled = true; };
-  }, [user]);
+  }, [user?.id]);
 
   async function handleLogout() {
     await supabase.auth.signOut();

--- a/src/Screens/HomeScreen.js
+++ b/src/Screens/HomeScreen.js
@@ -148,7 +148,7 @@ function HomeScreen() {
         num_vs: parseNumVs(gameSettings.format),
         latitude: lat,
         longitude: lon,
-        distance_preference: 50,
+        distance_preference: 100,
         is_casual: isCasual,
         skill_rating: isCasual ? null : 1000,
       });

--- a/src/Screens/HomeScreen.js
+++ b/src/Screens/HomeScreen.js
@@ -24,7 +24,9 @@ function HomeScreen() {
   const [invitedPlayers, setInvitedPlayers] = useState([]);
   const [searching, setSearching] = useState(false);
   const [myUserId, setMyUserId] = useState(null);
-  const [partyId, setPartyId] = useState(null); // set once we invite someone (ad-hoc party)
+  const [partyId, setPartyId] = useState(null); // my active ad-hoc party (as leader or member)
+  const [isLeader, setIsLeader] = useState(false);
+  const [partyMembers, setPartyMembers] = useState([]); // [{ user_id, username }]
 
   // resolve my integer app_user.user_id
   useEffect(() => {
@@ -35,17 +37,47 @@ function HomeScreen() {
     return () => { cancelled = true; };
   }, [user?.id]);
 
-  // recover an existing 'forming' party I lead, so re-renders/refreshes don't
-  // orphan it and spin up duplicates (partyId is otherwise ephemeral state)
+  // recover my active party — as leader OR member — so both see it across
+  // re-renders/refreshes and we don't orphan parties or spin up duplicates
   useEffect(() => {
     if (myUserId == null) return;
     let cancelled = false;
-    supabase.from('party').select('party_id')
-      .eq('leader_id', myUserId).eq('status', 'forming')
-      .order('party_id', { ascending: false }).limit(1).maybeSingle()
-      .then(({ data }) => { if (!cancelled && data) setPartyId(data.party_id); });
+    (async () => {
+      const { data } = await supabase
+        .from('party_member')
+        .select('party_id, party(party_id, leader_id, status)')
+        .eq('user_id', myUserId);
+      if (cancelled || !data) return;
+      const active = data.find(m => m.party && (m.party.status === 'forming' || m.party.status === 'queued'));
+      if (active) {
+        setPartyId(active.party_id);
+        setIsLeader(active.party.leader_id === myUserId);
+      }
+    })();
     return () => { cancelled = true; };
   }, [myUserId]);
+
+  // live party roster (shown on both the leader's and members' Home screens)
+  useEffect(() => {
+    if (partyId == null) return;
+    let cancelled = false;
+    async function loadMembers() {
+      const { data } = await supabase
+        .from('party_member')
+        .select('user_id, app_user(username)')
+        .eq('party_id', partyId);
+      if (cancelled || !data) return;
+      setPartyMembers(data.map(m => ({ user_id: m.user_id, username: m.app_user?.username ?? null })));
+    }
+    loadMembers();
+    const channel = supabase
+      .channel(`party-members-${partyId}`)
+      .on('postgres_changes',
+        { event: '*', schema: 'public', table: 'party_member', filter: `party_id=eq.${partyId}` },
+        () => loadMembers())
+      .subscribe();
+    return () => { cancelled = true; supabase.removeChannel(channel); };
+  }, [partyId]);
 
   async function handleLogout() {
     await supabase.auth.signOut();
@@ -66,6 +98,7 @@ function HomeScreen() {
       pid = party.party_id;
       await supabase.from('party_member').insert({ party_id: pid, user_id: myUserId });
       setPartyId(pid);
+      setIsLeader(true);
     }
     const { error: invErr } = await supabase
       .from('party_invite')
@@ -139,6 +172,10 @@ function HomeScreen() {
   }
 
   const invitedIds = invitedPlayers.map(p => p.id);
+  // party members other than me, shown in the lobby slots (realtime on both screens)
+  const otherMembers = partyMembers.filter(m => m.user_id !== myUserId);
+  // solo players can always search; in a party, only the leader can
+  const canSearch = partyId == null || isLeader;
 
   return (
     <div className="screen home-screen">
@@ -162,10 +199,10 @@ function HomeScreen() {
         </div>
 
         <div className="player-slots">
-          {invitedPlayers.slice(0, 3).map(player => (
-            <div className="slot avatar" key={player.id} title={`@${player.username}`} />
+          {otherMembers.slice(0, 3).map(m => (
+            <div className="slot avatar" key={m.user_id} title={m.username ? `@${m.username}` : ''} />
           ))}
-          {Array.from({ length: Math.max(0, 3 - invitedPlayers.length) }).map((_, i) => (
+          {Array.from({ length: Math.max(0, 3 - otherMembers.length) }).map((_, i) => (
             <div className="slot avatar empty" key={`empty-${i}`} aria-label="Player slot" />
           ))}
           <button
@@ -177,8 +214,8 @@ function HomeScreen() {
           </button>
         </div>
 
-        <button className="search-btn" onClick={handleSearch} disabled={searching}>
-          {searching ? 'SEARCHING…' : 'SEARCH'}
+        <button className="search-btn" onClick={handleSearch} disabled={searching || !canSearch}>
+          {!canSearch ? 'WAITING FOR LEADER…' : searching ? 'SEARCHING…' : 'SEARCH'}
         </button>
 
       </div>

--- a/src/Screens/HomeScreen.js
+++ b/src/Screens/HomeScreen.js
@@ -5,6 +5,7 @@ import { supabase } from '../supabaseClient';
 import { getCurrentLocation } from '../getLocation';
 import LobbyInviteModal from '../components/LobbyInviteModal';
 import ModifyGameModal from '../components/ModifyGameModal';
+import PlayerDot from '../components/PlayerDot';
 import './HomeScreen.css';
 
 // '4V4' -> 4, '2V2' -> 2, etc. Returns -1 ("any") if it can't parse.
@@ -46,7 +47,8 @@ function HomeScreen() {
       const { data } = await supabase
         .from('party_member')
         .select('party_id, party(party_id, leader_id, status)')
-        .eq('user_id', myUserId);
+        .eq('user_id', myUserId)
+        .order('party_member_id', { ascending: false }); // most-recent membership first
       if (cancelled || !data) return;
       const active = data.find(m => m.party && (m.party.status === 'forming' || m.party.status === 'queued'));
       if (active) {
@@ -64,10 +66,13 @@ function HomeScreen() {
     async function loadMembers() {
       const { data } = await supabase
         .from('party_member')
-        .select('user_id, app_user(username)')
+        .select('user_id, app_user(username, display_name)')
         .eq('party_id', partyId);
       if (cancelled || !data) return;
-      setPartyMembers(data.map(m => ({ user_id: m.user_id, username: m.app_user?.username ?? null })));
+      setPartyMembers(data.map(m => ({
+        user_id: m.user_id,
+        name: m.app_user?.display_name || m.app_user?.username || null,
+      })));
     }
     loadMembers();
     const channel = supabase
@@ -199,11 +204,8 @@ function HomeScreen() {
         </div>
 
         <div className="player-slots">
-          {otherMembers.slice(0, 3).map(m => (
-            <div className="slot avatar" key={m.user_id} title={m.username ? `@${m.username}` : ''} />
-          ))}
-          {Array.from({ length: Math.max(0, 3 - otherMembers.length) }).map((_, i) => (
-            <div className="slot avatar empty" key={`empty-${i}`} aria-label="Player slot" />
+          {otherMembers.map(m => (
+            <PlayerDot key={m.user_id} username={m.name} />
           ))}
           <button
             className="slot add-slot"

--- a/src/Screens/HomeScreen.js
+++ b/src/Screens/HomeScreen.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { supabase } from '../supabaseClient';
@@ -23,19 +23,49 @@ function HomeScreen() {
   const [gameSettings, setGameSettings] = useState(DEFAULT_SETTINGS);
   const [invitedPlayers, setInvitedPlayers] = useState([]);
   const [searching, setSearching] = useState(false);
+  const [myUserId, setMyUserId] = useState(null);
+  const [partyId, setPartyId] = useState(null); // set once we invite someone (ad-hoc party)
+
+  // resolve my integer app_user.user_id
+  useEffect(() => {
+    if (!user) return;
+    let cancelled = false;
+    supabase.from('app_user').select('user_id').eq('auth_id', user.id).maybeSingle()
+      .then(({ data }) => { if (!cancelled && data) setMyUserId(data.user_id); });
+    return () => { cancelled = true; };
+  }, [user]);
 
   async function handleLogout() {
     await supabase.auth.signOut();
     navigate('/');
   }
 
-  function handleInvite(friend) {
+  // Inviting a friend creates an ad-hoc party (lazily, on the first invite) and
+  // sends them a party_invite. They get a realtime popup to accept (PartyInviteListener).
+  async function handleInvite(friend) {
+    if (myUserId == null) return;
+    let pid = partyId;
+    if (pid == null) {
+      const { data: party, error } = await supabase
+        .from('party')
+        .insert({ leader_id: myUserId, isTeam: false, status: 'forming' })
+        .select('party_id').single();
+      if (error || !party) { alert('Could not create party: ' + (error?.message ?? '')); return; }
+      pid = party.party_id;
+      await supabase.from('party_member').insert({ party_id: pid, user_id: myUserId });
+      setPartyId(pid);
+    }
+    const { error: invErr } = await supabase
+      .from('party_invite')
+      .insert({ party_id: pid, inviter_id: myUserId, invitee_id: friend.id, status: 'pending' });
+    if (invErr) { alert('Could not send invite: ' + invErr.message); return; }
     setInvitedPlayers(prev => [...prev, friend]);
   }
 
-  // Solo queue flow: get location -> resolve our integer user_id -> insert a
-  // queue_entry row -> go to the Finding Game lobby, where realtime takes over.
-  // (Party queuing — leader inserts rows for all members — is a later step.)
+  // Queue flow (solo or party leader): get my location -> queue myself (with the
+  // party_id if I have a party) -> if I'm a party leader, flip the party to
+  // 'queued' so my accepted members self-queue with their own locations
+  // (PartyInviteListener) -> go to the Finding Game lobby.
   async function handleSearch() {
     if (searching) return;
     setSearching(true);
@@ -59,17 +89,18 @@ function HomeScreen() {
 
       const isCasual = gameSettings.mode === 'casual';
 
-      // 3. queue yourself. skill_rating must be NULL for casual; a real rating for
-      //    competitive. TODO: source the competitive rating from skill_rating/user_stats.
+      // 3. queue myself (share party_id when in a party so the matchmaker groups us).
+      //    skill_rating is NULL for casual, a real rating for competitive
+      //    (TODO: source from skill_rating/user_stats; placeholder for now).
       const { error: queueErr } = await supabase.from('queue_entry').insert({
         player_id: appUser.user_id,
-        party_id: null,                       // solo for now
+        party_id: partyId,
         num_vs: parseNumVs(gameSettings.format),
         latitude: lat,
         longitude: lon,
         distance_preference: 50,
         is_casual: isCasual,
-        skill_rating: isCasual ? null : 1000, // TODO: real competitive rating
+        skill_rating: isCasual ? null : 1000,
       });
       if (queueErr) {
         // PK conflict = already queued/in a game (queue_entry PK is player_id)
@@ -77,7 +108,12 @@ function HomeScreen() {
         return;
       }
 
-      // 4. hand off to the realtime lobby (haveBall is applied to our game_player row there)
+      // 4. if I'm leading a party, flip it to 'queued' -> members self-queue + follow
+      if (partyId != null) {
+        await supabase.from('party').update({ status: 'queued' }).eq('party_id', partyId);
+      }
+
+      // 5. hand off to the realtime lobby (haveBall is applied to our game_player row there)
       navigate('/FindingGameScreen', {
         state: {
           mode: gameSettings.mode,

--- a/src/Screens/HomeScreen.js
+++ b/src/Screens/HomeScreen.js
@@ -35,6 +35,18 @@ function HomeScreen() {
     return () => { cancelled = true; };
   }, [user?.id]);
 
+  // recover an existing 'forming' party I lead, so re-renders/refreshes don't
+  // orphan it and spin up duplicates (partyId is otherwise ephemeral state)
+  useEffect(() => {
+    if (myUserId == null) return;
+    let cancelled = false;
+    supabase.from('party').select('party_id')
+      .eq('leader_id', myUserId).eq('status', 'forming')
+      .order('party_id', { ascending: false }).limit(1).maybeSingle()
+      .then(({ data }) => { if (!cancelled && data) setPartyId(data.party_id); });
+    return () => { cancelled = true; };
+  }, [myUserId]);
+
   async function handleLogout() {
     await supabase.auth.signOut();
     navigate('/');

--- a/src/Screens/ProfileScreen.js
+++ b/src/Screens/ProfileScreen.js
@@ -96,7 +96,7 @@ function ProfileScreen() {
     return () => {
       if (channelRef.current) supabase.removeChannel(channelRef.current);
     };
-  }, [user]);
+  }, [user?.id]);
 
   function toggle(section) {
     setOpen(prev => (prev === section ? null : section));

--- a/src/Screens/ProfileScreen.js
+++ b/src/Screens/ProfileScreen.js
@@ -45,6 +45,12 @@ import './ProfileScreen.css';
 //      .eq('user_id', user.id);
 // ─────────────────────────────────────────────────────────────────────────────
 
+// timestamp -> "M/D"
+function formatMD(ts) {
+  const d = new Date(ts);
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}
+
 function ProfileScreen() {
   const { user } = useAuth();
   const navigate = useNavigate();
@@ -72,6 +78,25 @@ function ProfileScreen() {
     }));
   }
 
+  // win/loss record + ratings from user_stats, recent games from game_history_player
+  async function loadStats(uid) {
+    const { data: stats } = await supabase
+      .from('user_stats').select('skill, sportsmanship, wins, losses').eq('user_id', uid).maybeSingle();
+
+    const { data: games } = await supabase
+      .from('game_history_player').select('won, day')
+      .eq('user_id', uid).not('won', 'is', null)
+      .order('day', { ascending: false }).limit(5);
+
+    const recentGames = (games ?? []).map(g => ({
+      result: g.won ? 'WIN' : 'LOSS',
+      played_at: g.day ? formatMD(g.day) : '',
+    }));
+
+    setRecord({ wins: stats?.wins ?? 0, losses: stats?.losses ?? 0, recentGames });
+    setRatings({ skill: stats?.skill ?? 0, sportsmanship: stats?.sportsmanship ?? 0 });
+  }
+
   useEffect(() => {
     if (!user) return;
     supabase
@@ -83,6 +108,7 @@ function ProfileScreen() {
         if (!data) return;
         setProfile(data);
         loadFriends(data.user_id);
+        loadStats(data.user_id);
 
         if (channelRef.current) supabase.removeChannel(channelRef.current);
         channelRef.current = supabase
@@ -130,17 +156,16 @@ function ProfileScreen() {
           </div>
           {open === 'record' && (
             <div className="profile-section-body">
-              {record?.recentGames?.map((g, i) => (
+              {record?.recentGames?.length ? record.recentGames.map((g, i) => (
                 <div className="profile-game-row" key={i}>
                   <span className="profile-game-date">{g.played_at}</span>
                   <span className={`profile-game-result ${g.result === 'WIN' ? 'win' : 'loss'}`}>
                     {g.result}
                   </span>
                 </div>
-              ))}
-              <button className="profile-action-link" onClick={e => { e.stopPropagation(); navigate('/StatsScreen'); }}>
-                ALL STATS
-              </button>
+              )) : (
+                <span className="profile-game-date">No games yet</span>
+              )}
             </div>
           )}
         </div>
@@ -177,15 +202,10 @@ function ProfileScreen() {
             <div className="profile-section-body">
               {ratings && (
                 <>
-                  <span className="profile-rating-rank">
-                    {ratings.rank?.toUpperCase()} ({ratings.skill}) &rarr; {ratings.games_to_next} TO {ratings.next_rank?.toUpperCase()}
-                  </span>
+                  <span className="profile-rating-rank">SKILL: {ratings.skill}</span>
                   <span className="profile-rating-sport">SPORTSMANSHIP: {ratings.sportsmanship}</span>
                 </>
               )}
-              <button className="profile-action-link" onClick={e => e.stopPropagation()}>
-                FAQ
-              </button>
             </div>
           )}
         </div>

--- a/src/Screens/ProfileScreen.js
+++ b/src/Screens/ProfileScreen.js
@@ -97,6 +97,21 @@ function ProfileScreen() {
     setRatings({ skill: stats?.skill ?? 0, sportsmanship: stats?.sportsmanship ?? 0 });
   }
 
+  // my teams + each team's record (via the team_record SQL function)
+  async function loadTeams(uid) {
+    const { data: mems } = await supabase
+      .from('team_member').select('team_id, team(name)').eq('user_id', uid);
+    if (!mems) return;
+    const withRecords = await Promise.all(
+      mems.filter(m => m.team).map(async (m) => {
+        const { data: rec } = await supabase.rpc('team_record', { p_team_id: m.team_id });
+        const r = Array.isArray(rec) ? rec[0] : rec;
+        return { id: m.team_id, name: m.team.name, wins: r?.wins ?? 0, losses: r?.losses ?? 0 };
+      })
+    );
+    setTeams(withRecords);
+  }
+
   useEffect(() => {
     if (!user) return;
     supabase
@@ -109,6 +124,7 @@ function ProfileScreen() {
         setProfile(data);
         loadFriends(data.user_id);
         loadStats(data.user_id);
+        loadTeams(data.user_id);
 
         if (channelRef.current) supabase.removeChannel(channelRef.current);
         channelRef.current = supabase
@@ -218,8 +234,11 @@ function ProfileScreen() {
           </div>
           {open === 'teams' && (
             <div className="profile-section-body">
-              {teams?.map((t, i) => (
-                <span key={i} className="profile-team-name">
+              {teams && teams.length === 0 && (
+                <span className="profile-team-name">No teams yet</span>
+              )}
+              {teams?.map(t => (
+                <span key={t.id} className="profile-team-name">
                   {t.name.toUpperCase()} {t.wins}-{t.losses}
                 </span>
               ))}
@@ -239,7 +258,7 @@ function ProfileScreen() {
       )}
 
       {showTeamsModal && (
-        <ManageTeamsModal onClose={() => setShowTeamsModal(false)} />
+        <ManageTeamsModal onClose={() => { setShowTeamsModal(false); loadTeams(profile?.user_id); }} />
       )}
 
       <div className="profile-bottom-nav">

--- a/src/components/LobbyInviteModal.js
+++ b/src/components/LobbyInviteModal.js
@@ -40,7 +40,7 @@ function LobbyInviteModal({ onClose, onInvite, invitedIds = [] }) {
     }
 
     fetchFriends();
-  }, [user]);
+  }, [user?.id]);
 
   const filtered = friends.filter(f =>
     f.username.toLowerCase().includes(search.toLowerCase())

--- a/src/components/ManageFriendsModal.js
+++ b/src/components/ManageFriendsModal.js
@@ -26,9 +26,6 @@ function ManageFriendsModal({ onClose, myUserId: myUserIdProp, onFriendsChange }
         .eq('status', 'pending'),
     ]);
 
-    console.log('[Friends] friendsRes data:', friendsRes.data, 'error:', friendsRes.error);
-    console.log('[Friends] pendingRes data:', pendingRes.data, 'error:', pendingRes.error);
-
     if (friendsRes.data) {
       setFriends(friendsRes.data.map(r => {
         const friend = r.requester_id === userId ? r.receiver : r.requester;
@@ -62,11 +59,10 @@ function ManageFriendsModal({ onClose, myUserId: myUserIdProp, onFriendsChange }
           loadData(data.user_id);
         }
       });
-  }, [user, myUserIdProp, loadData]);
+  }, [user?.id, myUserIdProp, loadData]);
 
   async function handleDelete(friendshipId) {
     const { error } = await supabase.from('friendship').delete().eq('friendship_id', friendshipId);
-    console.log('[Friends] delete error:', error);
     if (!error) {
       setFriends(prev => prev.filter(f => f.id !== friendshipId));
       onFriendsChange?.();
@@ -98,6 +94,18 @@ function ManageFriendsModal({ onClose, myUserId: myUserIdProp, onFriendsChange }
       return;
     }
 
+    // block duplicates: any existing friendship/request in EITHER direction
+    const { data: existingRows } = await supabase
+      .from('friendship')
+      .select('status')
+      .or(`and(requester_id.eq.${myUserId},receiver_id.eq.${target.user_id}),and(requester_id.eq.${target.user_id},receiver_id.eq.${myUserId})`);
+    if (existingRows && existingRows.length > 0) {
+      setAddError(existingRows.some(r => r.status === 'accepted')
+        ? 'You are already friends.'
+        : 'A friend request already exists.');
+      return;
+    }
+
     const { error } = await supabase
       .from('friendship')
       .insert({ requester_id: myUserId, receiver_id: target.user_id, status: 'pending' });
@@ -116,7 +124,7 @@ function ManageFriendsModal({ onClose, myUserId: myUserIdProp, onFriendsChange }
       .from('friendship')
       .update({ status: 'accepted' })
       .eq('friendship_id', requestId);
-    console.log('[Friends] accept error:', error);
+    if (error) { setAddError('Could not accept request.'); return; }
     setPending(prev => prev.filter(p => p.id !== requestId));
     loadData(myUserId);
     onFriendsChange?.();

--- a/src/components/ManageTeamsModal.js
+++ b/src/components/ManageTeamsModal.js
@@ -1,53 +1,86 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../context/AuthContext';
+import { supabase } from '../supabaseClient';
 import './ManageTeamsModal.css';
 
-// ─── Supabase integration points ─────────────────────────────────────────────
-// 1. Fetch user's teams:
-//    const { data } = await supabase
-//      .from('team_members')
-//      .select('team:teams(id, name, wins, losses, captain_id)')
-//      .eq('user_id', user.id);
-//    setTeams(data.map(r => r.team));
-//
-// 2. Leave team:
-//    await supabase.from('team_members')
-//      .delete().eq('user_id', user.id).eq('team_id', teamId);
-//
-// 3. Create team:
-//    const { data } = await supabase.from('teams')
-//      .insert({ name: teamName, captain_id: user.id }).select().single();
-//    await supabase.from('team_members')
-//      .insert({ user_id: user.id, team_id: data.id });
-//
-// 4. Join team (by team name or code):
-//    const { data: team } = await supabase
-//      .from('teams').select('id').eq('name', teamName).single();
-//    await supabase.from('team_members')
-//      .insert({ user_id: user.id, team_id: team.id });
-// ─────────────────────────────────────────────────────────────────────────────
-
+// Persistent teams (stat-tracking only — no queue/invite flow). You create a team
+// and pick who's on it directly; members are added immediately (no acceptance).
+// A team's record comes from the team_record() SQL function (games where a side's
+// exact roster equals the team).
 function ManageTeamsModal({ onClose }) {
   const { user } = useAuth();
-  const [teams, setTeams] = useState([]);
+  const [myUserId, setMyUserId] = useState(null);
+  const [teams, setTeams] = useState([]);     // { id, name, wins, losses }
+  const [friends, setFriends] = useState([]); // { id, username }
   const [creating, setCreating] = useState(false);
   const [teamName, setTeamName] = useState('');
+  const [selected, setSelected] = useState([]); // chosen friend user_ids
+  const [error, setError] = useState('');
+
+  const loadTeams = useCallback(async (uid) => {
+    const { data: mems } = await supabase
+      .from('team_member').select('team_id, team(name)').eq('user_id', uid);
+    if (!mems) return;
+    const withRecords = await Promise.all(
+      mems.filter(m => m.team).map(async (m) => {
+        const { data: rec } = await supabase.rpc('team_record', { p_team_id: m.team_id });
+        const r = Array.isArray(rec) ? rec[0] : rec;
+        return { id: m.team_id, name: m.team.name, wins: r?.wins ?? 0, losses: r?.losses ?? 0 };
+      })
+    );
+    setTeams(withRecords);
+  }, []);
 
   useEffect(() => {
     if (!user) return;
-    // TODO: wire up Supabase fetch when teams table is ready
-  }, [user]);
+    let cancelled = false;
+    (async () => {
+      const { data: appUser } = await supabase
+        .from('app_user').select('user_id').eq('auth_id', user.id).maybeSingle();
+      if (!appUser || cancelled) return;
+      setMyUserId(appUser.user_id);
+      loadTeams(appUser.user_id);
 
-  function handleLeave(teamId) {
-    // TODO: supabase delete from team_members
-    setTeams(prev => prev.filter(t => t.id !== teamId));
+      const { data: fr } = await supabase
+        .from('friendship')
+        .select('requester_id, receiver_id, requester:app_user!friendship_requester_id_fkey(user_id, username), receiver:app_user!friendship_receiver_id_fkey(user_id, username)')
+        .or(`requester_id.eq.${appUser.user_id},receiver_id.eq.${appUser.user_id}`)
+        .eq('status', 'accepted');
+      if (fr && !cancelled) {
+        setFriends(fr.map(r => {
+          const f = r.requester_id === appUser.user_id ? r.receiver : r.requester;
+          return { id: f?.user_id, username: f?.username };
+        }).filter(f => f.id));
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [user?.id, loadTeams]);
+
+  function toggleSelect(fid) {
+    setSelected(prev => prev.includes(fid) ? prev.filter(x => x !== fid) : [...prev, fid]);
   }
 
-  function handleCreate() {
-    if (!teamName.trim()) return;
-    // TODO: supabase insert into teams + team_members
+  async function handleCreate() {
+    if (!teamName.trim() || myUserId == null) return;
+    setError('');
+    const { data: team, error: teamErr } = await supabase
+      .from('team').insert({ name: teamName.trim(), creator_id: myUserId }).select('team_id').single();
+    if (teamErr || !team) { setError('Could not create team: ' + (teamErr?.message ?? '')); return; }
+
+    const memberRows = [myUserId, ...selected].map(uid => ({ team_id: team.team_id, user_id: uid }));
+    const { error: memErr } = await supabase.from('team_member').insert(memberRows);
+    if (memErr) { setError('Team created, but could not add all members: ' + memErr.message); }
+
     setCreating(false);
     setTeamName('');
+    setSelected([]);
+    loadTeams(myUserId);
+  }
+
+  async function handleLeave(teamId) {
+    if (myUserId == null) return;
+    await supabase.from('team_member').delete().eq('team_id', teamId).eq('user_id', myUserId);
+    setTeams(prev => prev.filter(t => t.id !== teamId));
   }
 
   return (
@@ -60,6 +93,7 @@ function ManageTeamsModal({ onClose }) {
             <button className="mt-close" onClick={onClose} aria-label="Close">X</button>
           </div>
 
+          {teams.length === 0 && <p className="mt-pending-title">No teams yet</p>}
           {teams.map(t => (
             <div className="mt-team-row" key={t.id}>
               <span className="mt-team-name">{t.name.toUpperCase()} {t.wins}-{t.losses}</span>
@@ -68,35 +102,38 @@ function ManageTeamsModal({ onClose }) {
           ))}
 
           {creating ? (
-            <div className="mt-add-row">
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)', marginTop: 'var(--space-3)' }}>
               <input
                 className="mt-add-input"
                 type="text"
                 placeholder="TEAM NAME"
                 value={teamName}
                 onChange={e => setTeamName(e.target.value)}
-                onKeyDown={e => e.key === 'Enter' && handleCreate()}
                 autoFocus
               />
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)', maxHeight: 180, overflowY: 'auto' }}>
+                {friends.length === 0 && (
+                  <span className="mt-pending-title">Add friends first to put them on a team</span>
+                )}
+                {friends.map(f => (
+                  <label key={f.id} style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)', cursor: 'pointer' }}>
+                    <input
+                      type="checkbox"
+                      checked={selected.includes(f.id)}
+                      onChange={() => toggleSelect(f.id)}
+                    />
+                    @{f.username}
+                  </label>
+                ))}
+              </div>
               <button className="mt-send-btn" onClick={handleCreate}>CREATE</button>
+              {error && <p style={{ color: 'var(--color-reporter)', margin: 0 }}>{error}</p>}
             </div>
           ) : (
             <button className="mt-add-btn" onClick={() => setCreating(true)}>
               + (CREATE TEAM)
             </button>
           )}
-        </div>
-
-        <div className="mt-bottom">
-          <p className="mt-pending-title">JOIN A TEAM</p>
-          <div className="mt-add-row">
-            <input
-              className="mt-add-input"
-              type="text"
-              placeholder="TEAM NAME"
-            />
-            <button className="mt-send-btn">JOIN</button>
-          </div>
         </div>
 
       </div>

--- a/src/components/PartyInviteListener.css
+++ b/src/components/PartyInviteListener.css
@@ -1,0 +1,49 @@
+.party-invite-pop {
+  position: fixed;
+  top: var(--space-5);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  width: calc(100% - 2 * var(--page-padding-x));
+  max-width: 400px;
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+.party-invite-text {
+  font-size: var(--text-base);
+  color: var(--color-text);
+}
+
+.party-invite-actions {
+  display: flex;
+  gap: var(--space-3);
+}
+
+.party-invite-accept,
+.party-invite-decline {
+  flex: 1;
+  border: none;
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  font-family: var(--font-family);
+  font-weight: var(--font-black);
+  letter-spacing: 0.08em;
+  cursor: pointer;
+}
+
+.party-invite-accept {
+  background: var(--color-accent);
+  color: var(--color-modal-text);
+}
+
+.party-invite-decline {
+  background: transparent;
+  color: var(--color-text);
+  border: 1px solid var(--color-text-muted);
+}

--- a/src/components/PartyInviteListener.js
+++ b/src/components/PartyInviteListener.js
@@ -108,14 +108,20 @@ export default function PartyInviteListener() {
 
   async function accept() {
     if (!invite || myUserId == null) return;
-    await supabase.from('party_member').insert({ party_id: invite.party_id, user_id: myUserId });
-    await supabase.from('party_invite').update({ status: 'accepted' }).eq('invite_id', invite.invite_id);
+    const { error: memberErr } = await supabase
+      .from('party_member').insert({ party_id: invite.party_id, user_id: myUserId });
+    if (memberErr) { alert('Could not join party: ' + memberErr.message); return; }
+    const { error: inviteErr } = await supabase
+      .from('party_invite').update({ status: 'accepted' }).eq('invite_id', invite.invite_id);
+    if (inviteErr) { alert('Joined, but could not update invite: ' + inviteErr.message); }
     setInvite(null);
   }
 
   async function decline() {
     if (!invite) return;
-    await supabase.from('party_invite').update({ status: 'declined' }).eq('invite_id', invite.invite_id);
+    const { error } = await supabase
+      .from('party_invite').update({ status: 'declined' }).eq('invite_id', invite.invite_id);
+    if (error) { alert('Could not decline: ' + error.message); return; }
     setInvite(null);
   }
 

--- a/src/components/PartyInviteListener.js
+++ b/src/components/PartyInviteListener.js
@@ -107,7 +107,10 @@ export default function PartyInviteListener() {
   }, [myUserId, navigate]);
 
   async function accept() {
-    if (!invite || myUserId == null) return;
+    if (!invite || myUserId == null) {
+      alert('Not ready yet (still loading your account). Try again in a moment.');
+      return;
+    }
     const { error: memberErr } = await supabase
       .from('party_member').insert({ party_id: invite.party_id, user_id: myUserId });
     if (memberErr) { alert('Could not join party: ' + memberErr.message); return; }
@@ -115,6 +118,8 @@ export default function PartyInviteListener() {
       .from('party_invite').update({ status: 'accepted' }).eq('invite_id', invite.invite_id);
     if (inviteErr) { alert('Joined, but could not update invite: ' + inviteErr.message); }
     setInvite(null);
+    // head into the lobby to wait; the leader's SEARCH will queue me (status -> 'queued')
+    navigate('/FindingGameScreen');
   }
 
   async function decline() {

--- a/src/components/PartyInviteListener.js
+++ b/src/components/PartyInviteListener.js
@@ -91,11 +91,12 @@ export default function PartyInviteListener() {
           try { ({ lat, lon } = await getCurrentLocation()); }
           catch { alert('We need your location to join the game. Please enable location access.'); return; }
 
-          await supabase.from('queue_entry').insert({
+          const { error: queueErr } = await supabase.from('queue_entry').insert({
             player_id: myUserId, party_id: party.party_id, num_vs: numVs,
             latitude: lat, longitude: lon, distance_preference: 100,
             is_casual: isCasual, skill_rating: isCasual ? null : 1000,
           });
+          if (queueErr) { alert('Could not join the game queue: ' + queueErr.message); return; }
           navigate('/FindingGameScreen', {
             state: { mode: isCasual ? 'casual' : 'competitive', numVs },
           });

--- a/src/components/PartyInviteListener.js
+++ b/src/components/PartyInviteListener.js
@@ -1,0 +1,135 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import { supabase } from '../supabaseClient';
+import { getCurrentLocation } from '../getLocation';
+import './PartyInviteListener.css';
+
+// App-wide party listener (mounted at the router root). Two jobs:
+//   1. When someone invites me to a party (party_invite INSERT for me), show an
+//      Accept/Decline popup. Accept -> join party_member; Decline -> mark declined.
+//   2. When a party I'm in is queued by its leader (party.status -> 'queued'), I
+//      self-queue with MY OWN location + the shared party_id, then ride into the
+//      Finding Game lobby. (The leader queues + navigates itself, so it's skipped.)
+export default function PartyInviteListener() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [myUserId, setMyUserId] = useState(null);
+  const [invite, setInvite] = useState(null); // { invite_id, party_id, inviter_username }
+
+  // resolve my integer user_id
+  useEffect(() => {
+    if (!user) { setMyUserId(null); return; }
+    let cancelled = false;
+    supabase.from('app_user').select('user_id').eq('auth_id', user.id).maybeSingle()
+      .then(({ data }) => { if (!cancelled && data) setMyUserId(data.user_id); });
+    return () => { cancelled = true; };
+  }, [user]);
+
+  // incoming party invites
+  useEffect(() => {
+    if (myUserId == null) return;
+    let cancelled = false;
+
+    // surface any invite already pending when the app loads
+    (async () => {
+      const { data } = await supabase
+        .from('party_invite')
+        .select('invite_id, party_id, inviter:app_user!party_invite_inviter_id_fkey(username)')
+        .eq('invitee_id', myUserId).eq('status', 'pending')
+        .order('created_at', { ascending: false }).limit(1).maybeSingle();
+      if (!cancelled && data) {
+        setInvite({ invite_id: data.invite_id, party_id: data.party_id, inviter_username: data.inviter?.username });
+      }
+    })();
+
+    const channel = supabase
+      .channel(`party-invites-${myUserId}`)
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'party_invite', filter: `invitee_id=eq.${myUserId}` },
+        async (payload) => {
+          if (cancelled || payload.new.status !== 'pending') return;
+          const { data } = await supabase
+            .from('app_user').select('username').eq('user_id', payload.new.inviter_id).maybeSingle();
+          setInvite({ invite_id: payload.new.invite_id, party_id: payload.new.party_id, inviter_username: data?.username });
+        }
+      )
+      .subscribe();
+
+    return () => { cancelled = true; supabase.removeChannel(channel); };
+  }, [myUserId]);
+
+  // a party I'm in got queued -> self-queue with my own location + the party_id
+  useEffect(() => {
+    if (myUserId == null) return;
+    let cancelled = false;
+
+    const channel = supabase
+      .channel(`party-status-${myUserId}`)
+      .on(
+        'postgres_changes',
+        { event: 'UPDATE', schema: 'public', table: 'party' },
+        async (payload) => {
+          if (cancelled) return;
+          const party = payload.new;
+          if (party.status !== 'queued' || party.leader_id === myUserId) return; // leader self-queues elsewhere
+
+          // am I a member of this party?
+          const { data: membership } = await supabase
+            .from('party_member').select('party_member_id')
+            .eq('party_id', party.party_id).eq('user_id', myUserId).maybeSingle();
+          if (cancelled || !membership) return;
+
+          // mirror the leader's settings from a queue row for this party
+          const { data: leaderRow } = await supabase
+            .from('queue_entry').select('is_casual, num_vs').eq('party_id', party.party_id).limit(1).maybeSingle();
+          const isCasual = leaderRow?.is_casual ?? true;
+          const numVs = leaderRow?.num_vs ?? 5;
+
+          let lat, lon;
+          try { ({ lat, lon } = await getCurrentLocation()); }
+          catch { alert('We need your location to join the game. Please enable location access.'); return; }
+
+          await supabase.from('queue_entry').insert({
+            player_id: myUserId, party_id: party.party_id, num_vs: numVs,
+            latitude: lat, longitude: lon, distance_preference: 50,
+            is_casual: isCasual, skill_rating: isCasual ? null : 1000,
+          });
+          navigate('/FindingGameScreen', {
+            state: { mode: isCasual ? 'casual' : 'competitive', numVs },
+          });
+        }
+      )
+      .subscribe();
+
+    return () => { cancelled = true; supabase.removeChannel(channel); };
+  }, [myUserId, navigate]);
+
+  async function accept() {
+    if (!invite || myUserId == null) return;
+    await supabase.from('party_member').insert({ party_id: invite.party_id, user_id: myUserId });
+    await supabase.from('party_invite').update({ status: 'accepted' }).eq('invite_id', invite.invite_id);
+    setInvite(null);
+  }
+
+  async function decline() {
+    if (!invite) return;
+    await supabase.from('party_invite').update({ status: 'declined' }).eq('invite_id', invite.invite_id);
+    setInvite(null);
+  }
+
+  if (!invite) return null;
+
+  return (
+    <div className="party-invite-pop">
+      <span className="party-invite-text">
+        <strong>@{invite.inviter_username || 'someone'}</strong> invited you to their party
+      </span>
+      <div className="party-invite-actions">
+        <button className="party-invite-accept" onClick={accept}>ACCEPT</button>
+        <button className="party-invite-decline" onClick={decline}>DECLINE</button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/PartyInviteListener.js
+++ b/src/components/PartyInviteListener.js
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { supabase } from '../supabaseClient';
-import { getCurrentLocation } from '../getLocation';
 import './PartyInviteListener.css';
 
 // App-wide party listener (mounted at the router root). Two jobs:
@@ -81,19 +80,22 @@ export default function PartyInviteListener() {
             .eq('party_id', party.party_id).eq('user_id', myUserId).maybeSingle();
           if (cancelled || !membership) return;
 
-          // mirror the leader's settings from a queue row for this party
+          // use the LEADER's settings AND location for the whole party — simplest
+          // fix: no per-member geolocation prompt, so everyone's queue row lands
+          // together (closes the partial-team race window)
           const { data: leaderRow } = await supabase
-            .from('queue_entry').select('is_casual, num_vs').eq('party_id', party.party_id).limit(1).maybeSingle();
-          const isCasual = leaderRow?.is_casual ?? true;
-          const numVs = leaderRow?.num_vs ?? 5;
-
-          let lat, lon;
-          try { ({ lat, lon } = await getCurrentLocation()); }
-          catch { alert('We need your location to join the game. Please enable location access.'); return; }
+            .from('queue_entry').select('is_casual, num_vs, latitude, longitude')
+            .eq('player_id', party.leader_id).maybeSingle();
+          if (cancelled) return;
+          if (!leaderRow || leaderRow.latitude == null) {
+            alert('Could not find the party leader in the queue.'); return;
+          }
+          const isCasual = leaderRow.is_casual ?? true;
+          const numVs = leaderRow.num_vs ?? 5;
 
           const { error: queueErr } = await supabase.from('queue_entry').insert({
             player_id: myUserId, party_id: party.party_id, num_vs: numVs,
-            latitude: lat, longitude: lon, distance_preference: 100,
+            latitude: leaderRow.latitude, longitude: leaderRow.longitude, distance_preference: 100,
             is_casual: isCasual, skill_rating: isCasual ? null : 1000,
           });
           if (queueErr) { alert('Could not join the game queue: ' + queueErr.message); return; }

--- a/src/components/PartyInviteListener.js
+++ b/src/components/PartyInviteListener.js
@@ -93,7 +93,7 @@ export default function PartyInviteListener() {
 
           await supabase.from('queue_entry').insert({
             player_id: myUserId, party_id: party.party_id, num_vs: numVs,
-            latitude: lat, longitude: lon, distance_preference: 50,
+            latitude: lat, longitude: lon, distance_preference: 100,
             is_casual: isCasual, skill_rating: isCasual ? null : 1000,
           });
           navigate('/FindingGameScreen', {

--- a/src/components/PartyInviteListener.js
+++ b/src/components/PartyInviteListener.js
@@ -24,7 +24,7 @@ export default function PartyInviteListener() {
     supabase.from('app_user').select('user_id').eq('auth_id', user.id).maybeSingle()
       .then(({ data }) => { if (!cancelled && data) setMyUserId(data.user_id); });
     return () => { cancelled = true; };
-  }, [user]);
+  }, [user?.id]);
 
   // incoming party invites
   useEffect(() => {

--- a/src/components/PartyInviteListener.js
+++ b/src/components/PartyInviteListener.js
@@ -118,8 +118,9 @@ export default function PartyInviteListener() {
       .from('party_invite').update({ status: 'accepted' }).eq('invite_id', invite.invite_id);
     if (inviteErr) { alert('Joined, but could not update invite: ' + inviteErr.message); }
     setInvite(null);
-    // head into the lobby to wait; the leader's SEARCH will queue me (status -> 'queued')
-    navigate('/FindingGameScreen');
+    // go to Home and wait there with the party shown; the leader's SEARCH
+    // (party.status -> 'queued') is what pulls me into the Finding Game lobby.
+    navigate('/HomeScreen');
   }
 
   async function decline() {


### PR DESCRIPTION
Adds end-to-end ad-hoc party invites (realtime invite popup, accept -> party shown on both Home screens, leader SEARCH queues the whole party with a shared party_id) plus leave/disband party, and fixes the friends auth-churn re-render storm and duplicate friend requests.