### PR TITLE
Post-game flow: leave → win/loss → ratings

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import LoginScreen from './Screens/LoginScreen';
 import ProfileCreationScreen from './Screens/ProfileCreationScreen';
 import HomeScreen from './Screens/HomeScreen';
 import GameDetailsScreen from './Screens/GameDetailsScreen';
+import PostGameScreen from './Screens/PostGameScreen';
 import ProfileScreen from './Screens/ProfileScreen';
 import RatingScreen from './Screens/RatingScreen';
 import ProtectedRoute from './components/ProtectedRoute';
@@ -26,6 +27,14 @@ const router = createBrowserRouter([
     element: (
       <ProtectedRoute>
         <GameDetailsScreen />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/PostGameScreen',
+    element: (
+      <ProtectedRoute>
+        <PostGameScreen />
       </ProtectedRoute>
     ),
   },

--- a/src/Screens/GameDetailsScreen.js
+++ b/src/Screens/GameDetailsScreen.js
@@ -1,31 +1,33 @@
+import { useState, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { supabase } from '../supabaseClient';
 import { useAuth } from '../context/AuthContext';
 import './GameDetailsScreen.css';
 
 // ─── Supabase / matchmaking integration point ─────────────────────────────────
-// This screen receives game data via React Router location.state, passed from
-// the matchmaking algorithm once a game is found:
+// Reached from matchmaking with a real game id in router state:
 //
-//   navigate('/GameDetailsScreen', { state: { game } });
+//   navigate('/GameDetailsScreen', { state: { game: { game_id, is_casual } } });
 //
-// Competitive game shape:
-//   {
-//     mode: 'competitive',
-//     location: 'COMSTOCK PARK',
-//     time: '10:32',
-//     yourTeam: [{ id, username, isReporter, hasBall }],
-//     theirTeam: [{ id, username, isReporter, hasBall }],
-//   }
+// When a game_id is present we load the live roster from `game_player` (+ usernames
+// from `app_user`). Without one we fall back to mock data so the UI still renders
+// during development.
 //
-// Casual game shape:
-//   {
-//     mode: 'casual',
-//     location: 'COMSTOCK PARK',
-//     players: [{ id, username, hasBall }],
-//   }
+// Real tables: game(game_id, is_casual, is_active, park_id), game_player(game_id,
+// user_id, team_side, party_id), app_user(user_id, auth_id, username, display_name).
+// user_id is the integer app_user.user_id; the logged-in user maps via
+// app_user.auth_id = auth user.id.
+//
+// LEAVE behaviour:
+//   casual      → remove self from game_player, go Home (no rating, ever). The casual
+//                 game is also ended (is_active=false) the moment this screen loads.
+//   competitive → remove self from game_player, then captains go to /PostGameScreen
+//                 and everyone else goes to /RatingScreen.
+// NOTE: the per-player captain flag is provisioned by matchmaking later; until then
+// `is_captain` is false for everyone and competitive players route to rating.
 // ─────────────────────────────────────────────────────────────────────────────
 
-// Mock data for UI development — remove once matchmaking passes real data
+// Mock data for UI development — used when no game_id is passed in router state.
 const MOCK_COMPETITIVE = {
   mode: 'competitive',
   location: 'COMSTOCK PARK',
@@ -74,15 +76,115 @@ function PlayerCircle({ isReporter, hasBall, mode }) {
 function GameDetailsScreen() {
   const { state } = useLocation();
   const navigate = useNavigate();
+  const { user } = useAuth();
 
-  // Use real game data when passed from matchmaking, fall back to mock for dev
-  const game = state?.game ?? MOCK_CASUAL;
+  const incoming = state?.game;
+  const gameId = incoming?.game_id ?? null;
+
+  // Live roster loaded from Supabase (null until loaded / when running on mock).
+  const [live, setLive] = useState(null);
+
+  useEffect(() => {
+    if (!gameId || !user) return;
+    let active = true;
+
+    async function load() {
+      // map auth user → integer app_user.user_id
+      const { data: meRow } = await supabase
+        .from('app_user').select('user_id').eq('auth_id', user.id).single();
+      const myId = meRow?.user_id ?? null;
+
+      const { data: gameRow } = await supabase
+        .from('game').select('game_id, is_casual, is_active, park_id')
+        .eq('game_id', gameId).single();
+
+      const { data: players } = await supabase
+        .from('game_player').select('user_id, team_side, party_id')
+        .eq('game_id', gameId);
+
+      const ids = (players ?? []).map(p => p.user_id);
+      const { data: users } = ids.length
+        ? await supabase.from('app_user').select('user_id, username, display_name').in('user_id', ids)
+        : { data: [] };
+      const nameById = Object.fromEntries(
+        (users ?? []).map(u => [u.user_id, u.display_name || u.username])
+      );
+
+      const roster = (players ?? []).map(p => ({
+        id: p.user_id,
+        username: nameById[p.user_id] ?? `#${p.user_id}`,
+        team_side: p.team_side,
+        is_captain: false, // matchmaking will provide the captain flag later
+      }));
+      const mine = roster.find(p => p.id === myId);
+
+      if (!active) return;
+      setLive({
+        casual: gameRow?.is_casual ?? false,
+        park: gameRow?.park_id,
+        roster,
+        myId,
+        mySide: mine?.team_side ?? null,
+        amCaptain: !!mine?.is_captain,
+      });
+
+      // A casual game has nothing to resolve — end it as soon as details show.
+      if ((gameRow?.is_casual ?? false) && gameRow?.is_active) {
+        await supabase.from('game').update({ is_active: false }).eq('game_id', gameId);
+      }
+    }
+
+    load();
+    return () => { active = false; };
+  }, [gameId, user]);
+
+  // Build the view model from either live data or mock.
+  let game;
+  if (gameId) {
+    if (!live) return <div className="screen gd-screen" />; // loading
+    if (live.casual) {
+      game = {
+        mode: 'casual',
+        location: live.park != null ? `PARK ${live.park}` : '',
+        players: live.roster.map(p => ({ id: p.id, username: p.username, hasBall: false })),
+      };
+    } else {
+      const side = live.mySide ?? 1;
+      game = {
+        mode: 'competitive',
+        location: live.park != null ? `PARK ${live.park}` : '',
+        time: '',
+        yourTeam: live.roster.filter(p => p.team_side === side)
+          .map(p => ({ id: p.id, username: p.username, isReporter: p.is_captain, hasBall: false })),
+        theirTeam: live.roster.filter(p => p.team_side !== side)
+          .map(p => ({ id: p.id, username: p.username, isReporter: p.is_captain, hasBall: false })),
+      };
+    }
+  } else {
+    game = incoming?.mode === 'competitive' ? MOCK_COMPETITIVE : MOCK_CASUAL;
+  }
 
   const isCompetitive = game.mode === 'competitive';
 
-  function handleLeave() {
-    // TODO: notify matchmaking that user left
-    navigate('/HomeScreen');
+  async function handleLeave() {
+    // Real game: remove self from the live roster.
+    if (gameId && live?.myId != null) {
+      await supabase.from('game_player').delete()
+        .eq('game_id', gameId).eq('user_id', live.myId);
+    }
+
+    if (isCompetitive) {
+      const navState = { state: { game_id: gameId, mySide: live?.mySide ?? null } };
+      // Captains reconcile the result; everyone else goes straight to rating.
+      // In mock/dev mode (no gameId) route to PostGame so it stays reachable.
+      if (!gameId || live?.amCaptain) {
+        navigate('/PostGameScreen', navState);
+      } else {
+        navigate('/RatingScreen', navState);
+      }
+    } else {
+      navigate('/HomeScreen'); // casual: no rating
+    }
   }
 
   return (
@@ -122,12 +224,10 @@ function GameDetailsScreen() {
 
       <div className="gd-info">
         <span className="gd-location">{game.location}</span>
-        {isCompetitive && <span className="gd-time">{game.time}</span>}
+        {isCompetitive && game.time && <span className="gd-time">{game.time}</span>}
       </div>
 
-      {!isCompetitive && (
-        <button className="gd-leave-btn" onClick={handleLeave}>LEAVE</button>
-      )}
+      <button className="gd-leave-btn" onClick={handleLeave}>LEAVE</button>
 
       <div className="gd-bottom-nav">
         <button aria-label="Profile" onClick={() => navigate('/ProfileScreen')}>

--- a/src/Screens/GameDetailsScreen.js
+++ b/src/Screens/GameDetailsScreen.js
@@ -18,22 +18,10 @@ import './GameDetailsScreen.css';
 //                 everyone else goes straight to /RatingScreen.
 //
 // Captain: game_player has no is_captain column yet, so until matchmaking sets one
-// we DERIVE it — the highest-sportsmanship player on each team_side (tiebreak lowest
-// user_id) is the captain. Deterministic, so both clients agree. If a real is_captain
-// column appears later, it takes precedence automatically.
+// we DERIVE it via the game_captains() RPC — highest sportsmanship per team_side
+// (tiebreak lowest user_id). It runs server-side because user_stats RLS hides other
+// players' rows from the client, so a client-side pick would be wrong.
 // ───────────────────────────────────────────────────────────────────────────────
-
-// captain = highest sportsmanship on a team, tiebreak lowest user_id
-function pickCaptain(players) {
-  if (!players.length) return null;
-  return players.reduce((best, p) => {
-    const bs = best.sportsmanship ?? -Infinity;
-    const ps = p.sportsmanship ?? -Infinity;
-    if (ps > bs) return p;
-    if (ps === bs && p.user_id < best.user_id) return p;
-    return best;
-  });
-}
 
 function GameDetailsScreen() {
   const { state } = useLocation();
@@ -70,29 +58,17 @@ function GameDetailsScreen() {
         .eq('game_id', gameId);
       if (cancelled || !data) return;
 
-      // sportsmanship powers the derived captain (no is_captain column yet)
-      const ids = data.map((r) => r.user_id);
-      const { data: stats } = ids.length
-        ? await supabase.from('user_stats').select('user_id, sportsmanship').in('user_id', ids)
-        : { data: [] };
-      const sportById = Object.fromEntries((stats ?? []).map((s) => [s.user_id, s.sportsmanship]));
+      // captains computed server-side (RLS hides other players' sportsmanship)
+      const { data: caps } = await supabase.rpc('game_captains', { p_game_id: gameId });
+      const captainIds = new Set((caps ?? []).map((c) => c.user_id));
 
       const next = data.map((r) => ({
         user_id: r.user_id,
         team_side: r.team_side,
         username: r.app_user?.username ?? null,
         has_ball: r.has_ball,                 // undefined until the column exists
-        sportsmanship: sportById[r.user_id] ?? null,
-        is_captain: r.is_captain ?? false,    // prefer the real column when it exists
+        is_captain: captainIds.has(r.user_id),
       }));
-
-      // no real captain flag yet → derive one per side from sportsmanship
-      if (!next.some((p) => p.is_captain)) {
-        for (const side of [1, 2]) {
-          const cap = pickCaptain(next.filter((p) => p.team_side === side));
-          if (cap) cap.is_captain = true;
-        }
-      }
 
       if (!cancelled) setRoster(next);
     }

--- a/src/Screens/PostGameScreen.css
+++ b/src/Screens/PostGameScreen.css
@@ -1,0 +1,105 @@
+.pg-screen {
+  justify-content: space-between;
+  height: 100svh;
+  overflow: hidden;
+}
+
+/* ── "POST GAME" heading ── */
+.pg-title {
+  font-size: var(--text-hero);
+  font-weight: var(--font-black);
+  line-height: 0.88;
+  letter-spacing: -0.02em;
+  color: var(--color-text);
+  text-transform: uppercase;
+  margin: 0;
+  padding-top: var(--space-10);
+}
+
+/* ── WIN / LOSS options ── */
+.pg-options {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0;
+  width: 100%;
+  flex: 1;
+  justify-content: center;
+}
+
+.pg-option {
+  background: none;
+  border: none;
+  color: var(--color-text);
+  font-family: var(--font-family);
+  font-size: var(--text-2xl);
+  font-weight: var(--font-black);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  cursor: pointer;
+  padding: var(--space-5) 0;
+  width: 100%;
+  text-align: center;
+  transition: opacity var(--transition-fast);
+}
+
+.pg-option:active {
+  opacity: 0.6;
+}
+
+.pg-divider {
+  width: 100%;
+  height: 1px;
+  background: var(--color-text);
+  opacity: 0.3;
+}
+
+/* ── reconciliation states (waiting / conflict / ended) ── */
+.pg-status {
+  font-size: var(--text-2xl);
+  font-weight: var(--font-black);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-text);
+  text-align: center;
+}
+
+.pg-message {
+  color: var(--color-text-muted);
+  font-size: var(--text-base);
+  text-align: center;
+  max-width: 28ch;
+  margin: var(--space-4) auto 0;
+  line-height: 1.4;
+}
+
+.pg-warning {
+  color: var(--color-accent);
+  font-size: var(--text-sm);
+  font-weight: var(--font-bold);
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  max-width: 30ch;
+  margin: var(--space-4) auto 0;
+  line-height: 1.4;
+}
+
+.pg-continue {
+  background: none;
+  border: 1px solid var(--color-text);
+  color: var(--color-text);
+  font-family: var(--font-family);
+  font-size: var(--text-base);
+  font-weight: var(--font-bold);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  padding: var(--space-4) var(--space-6);
+  margin: 0 auto var(--space-10);
+  border-radius: var(--radius-full);
+}
+
+.pg-continue:active {
+  opacity: 0.6;
+}

--- a/src/Screens/PostGameScreen.js
+++ b/src/Screens/PostGameScreen.js
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { supabase } from '../supabaseClient';
+import './PostGameScreen.css';
+
+// ─── Captain win/loss reporting ───────────────────────────────────────────────
+// Reached from GameDetailsScreen (captains only) with:
+//
+//   navigate('/PostGameScreen', { state: { game_id, mySide } });
+//
+// The captain reports whether THEIR team won; the `report_game_result` RPC
+// normalizes it to game.team1_wins and reconciles the two captains:
+//   'recorded'        – first captain reported, waiting on the other
+//   'finalized'       – both agreed; history.won set, game deleted
+//   'conflict'        – the captains disagree; re-report (-2 sportsmanship to the reporter)
+//   'ended_no_result' – disagreed more than twice; game ended with no result
+//
+// Without a game_id (dev/mock) it just forwards to the rating flow.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function PostGameScreen() {
+  const { state } = useLocation();
+  const navigate = useNavigate();
+
+  const gameId = state?.game_id ?? null;
+  const mySide = state?.mySide ?? null;
+  const usingMock = gameId == null;
+
+  const [phase, setPhase] = useState('choose'); // choose | waiting | conflict | ended
+  const [submitting, setSubmitting] = useState(false);
+
+  function goRate() {
+    navigate('/RatingScreen', { state: { game_id: gameId, mySide } });
+  }
+
+  async function handleResult(result) {
+    if (submitting) return;
+    setSubmitting(true);
+
+    if (usingMock) {
+      goRate();
+      return;
+    }
+
+    const { data: status, error } = await supabase.rpc('report_game_result', {
+      p_game_id: gameId,
+      p_team_won: result === 'win',
+    });
+    setSubmitting(false);
+
+    if (error) {
+      console.error('[PostGame] report_game_result failed:', error);
+      return;
+    }
+
+    if (status === 'finalized') goRate();
+    else if (status === 'recorded') setPhase('waiting');
+    else if (status === 'conflict') setPhase('conflict');
+    else if (status === 'ended_no_result') setPhase('ended');
+  }
+
+  // Result recorded — this captain is done; the other still has to confirm.
+  if (phase === 'waiting') {
+    return (
+      <div className="screen pg-screen">
+        <h1 className="pg-title">POST<br />GAME</h1>
+        <div className="pg-options">
+          <span className="pg-status">RESULT RECORDED</span>
+          <p className="pg-message">Waiting for the other captain to confirm.</p>
+        </div>
+        <button className="pg-continue" onClick={goRate}>CONTINUE TO RATINGS</button>
+      </div>
+    );
+  }
+
+  // Force-ended after disagreeing more than twice.
+  if (phase === 'ended') {
+    return (
+      <div className="screen pg-screen">
+        <h1 className="pg-title">NO<br />RESULT</h1>
+        <div className="pg-options">
+          <p className="pg-message">
+            The captains couldn't agree — the game ended with no result.
+          </p>
+        </div>
+        <button className="pg-continue" onClick={goRate}>CONTINUE TO RATINGS</button>
+      </div>
+    );
+  }
+
+  const inConflict = phase === 'conflict';
+
+  return (
+    <div className="screen pg-screen">
+
+      <h1 className="pg-title">POST<br />GAME</h1>
+
+      {inConflict && (
+        <p className="pg-warning">
+          You and the other captain disagree. Reporting a conflicting result
+          costs you sportsmanship.
+        </p>
+      )}
+
+      <div className="pg-options">
+        <button className="pg-option" onClick={() => handleResult('win')} disabled={submitting}>WIN</button>
+        <div className="pg-divider" />
+        <button className="pg-option" onClick={() => handleResult('loss')} disabled={submitting}>LOSS</button>
+      </div>
+
+    </div>
+  );
+}
+
+export default PostGameScreen;

--- a/src/Screens/RatingScreen.js
+++ b/src/Screens/RatingScreen.js
@@ -9,11 +9,12 @@ import './RatingScreen.css';
 //
 //   navigate('/RatingScreen', { state: { gameId, mySide } });
 //
-// Builds the queue from the permanent `game_history_player` roster, in order:
-//   1. the OTHER team   → rate sportsmanship   (skippable)
-//   2. YOUR team        → rate skill           (skippable)
-// Each rating calls the `rate_player` RPC, which adjusts the target's
-// user_stats by (rating - 3): 1→-2, 3→0, 5→+2. SKIP submits nothing.
+// Each player rates the OTHER team's sportsmanship, then YOUR team's skill (both
+// skippable), via rate_player → adjusts the target's user_stats column by
+// (rating - 3): 1→-2, 3→0, 5→+2. SKIP submits nothing.
+//
+// Skill is ALSO adjusted automatically at game finalize from the team skill
+// differential (see report_game_result); these peer ratings stack on top of that.
 //
 // Without a game_id (dev/mock) it runs on mock data and submits nothing.
 // ─────────────────────────────────────────────────────────────────────────────
@@ -65,7 +66,7 @@ function RatingScreen() {
         (users ?? []).map(u => [u.user_id, u.display_name || u.username])
       );
 
-      // opponents first (sportsmanship), then teammates (skill)
+      // opponents first (rate sportsmanship), then teammates (rate skill)
       const opponents = others.filter(r => r.team_side !== mySide)
         .map(r => ({ id: r.user_id, username: nameById[r.user_id] ?? `#${r.user_id}`, type: 'sportsmanship' }));
       const teammates = others.filter(r => r.team_side === mySide)

--- a/src/Screens/RatingScreen.js
+++ b/src/Screens/RatingScreen.js
@@ -1,30 +1,28 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { supabase } from '../supabaseClient';
+import { useAuth } from '../context/AuthContext';
 import './RatingScreen.css';
 
-// ─── Supabase integration point ───────────────────────────────────────────────
-// Receives rating queue via React Router location.state from GameDetailsScreen
-// once the game is completed:
+// ─── Post-game ratings (competitive only) ─────────────────────────────────────
+// Reached from GameDetailsScreen / PostGameScreen with:
 //
-//   navigate('/RatingScreen', { state: { queue } });
+//   navigate('/RatingScreen', { state: { game_id, mySide } });
 //
-// Queue shape:
-//   [
-//     { id, username, type: 'skill' },          // teammates — rate skill
-//     { id, username, type: 'sportsmanship' },  // opponents — rate sportsmanship
-//   ]
+// Builds the queue from the permanent `game_history_player` roster, in order:
+//   1. the OTHER team   → rate sportsmanship   (skippable)
+//   2. YOUR team        → rate skill           (skippable)
+// Each rating calls the `rate_player` RPC, which adjusts the target's
+// user_stats by (rating - 3): 1→-2, 3→0, 5→+2. SKIP submits nothing.
 //
-// On completion, submit ratings to Supabase:
-//   for each rated player:
-//     await supabase.from('ratings')
-//       .upsert({ user_id: player.id, [type]: rating, rated_by: currentUser.id });
+// Without a game_id (dev/mock) it runs on mock data and submits nothing.
 // ─────────────────────────────────────────────────────────────────────────────
 
 const MOCK_QUEUE = [
-  { id: '1', username: 'TOM',    type: 'skill' },
-  { id: '2', username: 'SARAH',  type: 'skill' },
-  { id: '3', username: 'JIM',    type: 'sportsmanship' },
-  { id: '4', username: 'ALEX',   type: 'sportsmanship' },
+  { id: '3', username: 'JIM',   type: 'sportsmanship' },
+  { id: '4', username: 'ALEX',  type: 'sportsmanship' },
+  { id: '1', username: 'TOM',   type: 'skill' },
+  { id: '2', username: 'SARAH', type: 'skill' },
 ];
 
 const DOTS = 5;
@@ -32,25 +30,79 @@ const DOTS = 5;
 function RatingScreen() {
   const { state } = useLocation();
   const navigate = useNavigate();
-  const queue = state?.queue ?? MOCK_QUEUE;
+  const { user } = useAuth();
 
-  const [index, setIndex]   = useState(0);
+  const gameId = state?.game_id ?? null;
+  const usingMock = gameId == null;
+
+  const [queue, setQueue] = useState(usingMock ? MOCK_QUEUE : null);
+  const [index, setIndex] = useState(0);
   const [selected, setSelected] = useState(0);
-  const [ratings, setRatings]   = useState({});
+
+  // Load the rating queue from the persistent history roster.
+  useEffect(() => {
+    if (usingMock || !user) return;
+    let active = true;
+
+    async function load() {
+      const { data: meRow } = await supabase
+        .from('app_user').select('user_id').eq('auth_id', user.id).single();
+      const myId = meRow?.user_id ?? null;
+
+      const { data: rows } = await supabase
+        .from('game_history_player').select('user_id, team_side')
+        .eq('game_id', gameId);
+
+      const mine = (rows ?? []).find(r => r.user_id === myId);
+      const mySide = state?.mySide ?? mine?.team_side ?? null;
+
+      const others = (rows ?? []).filter(r => r.user_id !== myId);
+      const ids = others.map(r => r.user_id);
+      const { data: users } = ids.length
+        ? await supabase.from('app_user').select('user_id, username, display_name').in('user_id', ids)
+        : { data: [] };
+      const nameById = Object.fromEntries(
+        (users ?? []).map(u => [u.user_id, u.display_name || u.username])
+      );
+
+      // opponents first (sportsmanship), then teammates (skill)
+      const opponents = others.filter(r => r.team_side !== mySide)
+        .map(r => ({ id: r.user_id, username: nameById[r.user_id] ?? `#${r.user_id}`, type: 'sportsmanship' }));
+      const teammates = others.filter(r => r.team_side === mySide)
+        .map(r => ({ id: r.user_id, username: nameById[r.user_id] ?? `#${r.user_id}`, type: 'skill' }));
+
+      if (!active) return;
+      setQueue([...opponents, ...teammates]);
+    }
+
+    load();
+    return () => { active = false; };
+  }, [gameId, usingMock, user, state]);
+
+  // Nothing to rate (e.g. solo game) — bounce home.
+  useEffect(() => {
+    if (queue && queue.length === 0) navigate('/HomeScreen');
+  }, [queue, navigate]);
+
+  if (!queue || queue.length === 0) return <div className="screen rating-screen" />; // loading / empty
 
   const current = queue[index];
 
-  function advance(rating) {
-    const next = { ...ratings };
-    if (rating) next[current.id] = rating;
-    setRatings(next);
+  async function advance(rating) {
+    if (rating && !usingMock) {
+      const { error } = await supabase.rpc('rate_player', {
+        p_game_id: gameId,
+        p_target_user: current.id,
+        p_kind: current.type,
+        p_rating: rating,
+      });
+      if (error) console.error('[Rating] rate_player failed:', error);
+    }
 
     if (index < queue.length - 1) {
       setIndex(i => i + 1);
       setSelected(0);
     } else {
-      // TODO: submit `next` to Supabase, then navigate back
-      console.log('[RATINGS] submitted:', next);
       navigate('/HomeScreen');
     }
   }

--- a/src/components/PlayerDot.css
+++ b/src/components/PlayerDot.css
@@ -11,7 +11,18 @@
   height: 72px;
   border-radius: var(--radius-full);
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   transition: background 0.25s ease, transform 0.2s ease;
+}
+
+/* white "C" marker for the captain dot */
+.player-dot-label {
+  font-size: var(--text-lg);
+  font-weight: var(--font-black);
+  color: var(--color-text);
+  line-height: 1;
 }
 
 /* dim, empty waiting slot */

--- a/src/components/PlayerDot.js
+++ b/src/components/PlayerDot.js
@@ -4,7 +4,7 @@ import './PlayerDot.css';
 //   empty   -> dim waiting slot (no name)
 //   filled  -> bright white (a real player joined)
 //   ball     -> purple fill (bringing the ball)
-//   captain  -> red fill (team captain)
+//   captain  -> red fill with a white "C" (team captain)
 // If a player is BOTH captain and has the ball, the fill is red (captain) and a
 // purple ring is drawn around it so both roles are visible.
 export default function PlayerDot({ username, hasBall, isCaptain, empty }) {
@@ -18,7 +18,9 @@ export default function PlayerDot({ username, hasBall, isCaptain, empty }) {
 
   return (
     <div className="player-dot-wrap">
-      <div className={`player-dot player-dot--${fill} ${ballRing ? 'player-dot--ball-ring' : ''}`} />
+      <div className={`player-dot player-dot--${fill} ${ballRing ? 'player-dot--ball-ring' : ''}`}>
+        {!empty && isCaptain && <span className="player-dot-label">C</span>}
+      </div>
       <span className="player-dot-name">{empty ? '' : (username || '…')}</span>
     </div>
   );


### PR DESCRIPTION
## What this adds
The post-game second half, wired onto the realtime lobby/matchmaking first half (already merged into dev).

**Flow:** Game Details → LEAVE
- **Casual** → leave game, go Home (no rating; casual game ended on load).
- **Competitive** → captains report win/loss, everyone rates afterward.

### Screens
- **GameDetailsScreen** — derives the team captain server-side (`game_captains` RPC = highest sportsmanship per team) and shows the red **"C"** via `PlayerDot`; LEAVE branches casual vs competitive.
- **PostGameScreen** — captains report WIN/LOSS; reconciles via `report_game_result` (`recorded` / `finalized` / `conflict` / `ended_no_result`), with a conflict warning + sportsmanship penalty.
- **RatingScreen** — rate the other team's sportsmanship, then your team's skill (both skippable).

### Behavior on finalize
- Sets `game_history_player.won` per side, records `user_stats.wins/losses`, applies the **team skill differential**, then deletes the game.
- Disagreement docks the reporter −2 sportsmanship; >2 disagreements ends with no result.

## ⚠️ Database changes are already live on the shared Supabase
Per the repo convention, `supabase/` isn't git-tracked, so the SQL isn't in this diff — but these objects are **already deployed** to the shared remote DB:
- trigger `mirror_game_player_to_history` (game_player → game_history_player)
- `game.dispute_count` column
- functions: `report_game_result`, `rate_player`, `game_captains`, `is_game_member`
- RLS policies for member reads / leaving

## Notes
- Captain is **derived** (top sportsmanship) until matchmaking sets a real `is_captain` column.
- Skill differential uses each team's **average** skill; always a gain (per spec, no win/loss sign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)