### PR TITLE
Fix Finding Game title overflow + matchmaking screen polish

### DIFF
--- a/src/Screens/FindingGameScreen.css
+++ b/src/Screens/FindingGameScreen.css
@@ -119,10 +119,10 @@
   background: var(--color-text);   /* joined player — white */
 }
 
-/* ── Cancel / Chat ── */
+/* ── Chat ── */
 .fg-actions {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   width: 100%;
   padding: 0 var(--space-2);
 }

--- a/src/Screens/FindingGameScreen.css
+++ b/src/Screens/FindingGameScreen.css
@@ -9,7 +9,9 @@
 
 /* ── Title ── */
 .fg-title {
-  font-size: var(--text-hero);
+  /* "FINDING" is 7 chars vs the hero token's 4-char "PLAY"/"NOW", so the shared
+     --text-hero clamp overflows the 430px frame. Cap it lower for this word. */
+  font-size: clamp(3.5rem, 18vw, 5.5rem);
   font-weight: var(--font-black);
   line-height: 0.88;
   letter-spacing: -0.02em;
@@ -19,6 +21,29 @@
   padding-top: var(--space-10);
   width: 100%;
   text-align: left;
+}
+
+/* Animated ellipsis trailing "GAME" — signals matchmaking is in progress.
+   Dots fade in sequence (left→right) on a loop. Accent color to read as activity. */
+.fg-title-dots {
+  display: inline-block;
+  margin-left: 0.08em;
+  color: var(--color-icon);
+}
+
+.fg-title-dots span {
+  animation: fg-dot-fade 1.4s ease-in-out infinite both;
+}
+.fg-title-dots span:nth-child(2) { animation-delay: 0.2s; }
+.fg-title-dots span:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes fg-dot-fade {
+  0%, 70%, 100% { opacity: 0.2; }
+  35%            { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fg-title-dots span { animation: none; opacity: 0.6; }
 }
 
 /* ── Mode / sport / park ── */
@@ -31,18 +56,19 @@
 }
 
 .fg-mode {
-  font-size: var(--text-2xl);
+  font-size: var(--text-xl);
   font-weight: var(--font-black);
   color: var(--color-accent);
-  letter-spacing: 0.02em;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
   line-height: 1;
 }
 
 .fg-sport {
-  font-size: var(--text-2xl);
+  font-size: var(--text-xl);
   font-weight: var(--font-black);
   color: var(--color-text);
+  letter-spacing: 0.04em;
   text-transform: uppercase;
   line-height: 1;
 }

--- a/src/Screens/FindingGameScreen.js
+++ b/src/Screens/FindingGameScreen.js
@@ -140,7 +140,9 @@ function FindingGameScreen() {
 
   return (
     <div className="screen fg-screen">
-      <h1 className="fg-title">FINDING<br />GAME</h1>
+      <h1 className="fg-title">
+        FINDING<br />GAME<span className="fg-title-dots" aria-hidden="true"><span>.</span><span>.</span><span>.</span></span>
+      </h1>
 
       <div className="fg-meta">
         <span className="fg-mode">{mode === 'competitive' ? 'COMPETITIVE' : 'CASUAL'}</span>

--- a/src/Screens/FindingGameScreen.js
+++ b/src/Screens/FindingGameScreen.js
@@ -124,6 +124,7 @@ function FindingGameScreen() {
     return () => { cancelled = true; supabase.removeChannel(channel); };
   }, [gameId, mode, navigate]);
 
+  // eslint-disable-next-line no-unused-vars -- CANCEL button removed; logic kept for future re-add
   async function handleCancel() {
     if (user) {
       const { data: appUser } = await supabase
@@ -163,7 +164,6 @@ function FindingGameScreen() {
       </div>
 
       <div className="fg-actions">
-        <button className="fg-action-btn" onClick={handleCancel}>CANCEL</button>
         <button className="fg-action-btn" onClick={() => { setShowGameChat(true); }}>CHAT</button>
 
         {showGameChat && (


### PR DESCRIPTION
## Summary

UI-only fixes to the Finding Game (matchmaking lobby) screen. **No logic changed** — all effects, Supabase queries, realtime subscriptions, and navigation are untouched.

### Changes
- **Title overflow fix** — "FINDING" (7 chars) overflowed the right edge because `.fg-title` reused the shared `--text-hero` clamp tuned for the 4-char "PLAY"/"NOW" hero. Capped this screen's title at `clamp(3.5rem, 18vw, 5.5rem)` so the longer word fits the 430px frame. Shared token and other heroes (Home/Rating/PostGame) untouched.
- **CASUAL / BASKETBALL resized** to match the Home screen (`--text-xl`, `0.04em` letter-spacing; was `--text-2xl`).
- **Animated ellipsis** trailing "GAME" to signal matchmaking in progress — sequential fade, muted gray, respects `prefers-reduced-motion`.
- **Removed CANCEL button**; right-aligned the remaining CHAT button. `handleCancel` logic kept intact (now unused, eslint-suppressed) for easy re-add.

### Notes
- `handleCancel` is preserved verbatim — only its triggering button was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)