### PR TITLE
Game Details overflow fix + enable 5v5 (lobby/details layout)

### DIFF
--- a/src/Screens/FindingGameScreen.css
+++ b/src/Screens/FindingGameScreen.css
@@ -102,9 +102,15 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-start;
-  gap: var(--space-4);
-  max-width: 340px;
+  gap: var(--space-3);
+  max-width: 360px;     /* 5 bubbles per row → a full 5v5 (10) packs to 2 rows */
 }
+
+/* Shrink the player bubbles so 5 fit per row (5×60 + 4 gaps ≈ 348 ≤ 360).
+   Keeps a 9–10 player lobby to 2 rows so the layout doesn't crowd the title. */
+.fg-players .player-dot-wrap { width: 60px; }
+.fg-players .player-dot      { width: 60px; height: 60px; }
+.fg-players .player-dot-name { max-width: 60px; }
 
 .fg-dot {
   width: 72px;

--- a/src/Screens/GameDetailsScreen.css
+++ b/src/Screens/GameDetailsScreen.css
@@ -9,7 +9,9 @@
 
 /* ── Title ── */
 .gd-title {
-  font-size: var(--text-hero);
+  /* "DETAILS" is 7 chars vs the hero token's 4-char "PLAY"/"NOW", so the shared
+     --text-hero clamp overflows the 430px frame. Cap it lower for this word. */
+  font-size: clamp(3.5rem, 18vw, 5.5rem);
   font-weight: var(--font-black);
   line-height: 0.88;
   letter-spacing: -0.02em;

--- a/src/Screens/GameDetailsScreen.css
+++ b/src/Screens/GameDetailsScreen.css
@@ -48,19 +48,25 @@
 
 .gd-circles-row {
   display: flex;
-  flex-wrap: wrap;        /* 5-per-side teams wrap instead of overflowing the frame */
+  flex-wrap: wrap;        /* safety net; with 60px bubbles a full 5-side fits one row */
   justify-content: flex-start;
-  gap: var(--space-4);
-  max-width: 340px;
+  gap: var(--space-3);
+  max-width: 360px;
 }
 
 .gd-circles-grid {
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-start;
-  gap: var(--space-4);
-  max-width: 340px;
+  gap: var(--space-3);
+  max-width: 360px;       /* 5 bubbles per row → casual 5v5 (10) packs to 2 rows */
 }
+
+/* Shrink the player bubbles on this screen so a full 5-person side stays on one
+   row (5×60 + 4 gaps ≈ 348px ≤ 360). Keeps 5v5 the same height as 4v4. */
+.gd-teams .player-dot-wrap { width: 60px; }
+.gd-teams .player-dot      { width: 60px; height: 60px; }
+.gd-teams .player-dot-name { max-width: 60px; }
 
 /* ── Player circle ── */
 .gd-circle {

--- a/src/Screens/GameDetailsScreen.css
+++ b/src/Screens/GameDetailsScreen.css
@@ -48,8 +48,10 @@
 
 .gd-circles-row {
   display: flex;
+  flex-wrap: wrap;        /* 5-per-side teams wrap instead of overflowing the frame */
   justify-content: flex-start;
   gap: var(--space-4);
+  max-width: 340px;
 }
 
 .gd-circles-grid {

--- a/src/components/ModifyGameModal.js
+++ b/src/components/ModifyGameModal.js
@@ -20,8 +20,8 @@ function ModifyGameModal({ settings, onClose, onDone }) {
         <div className="mode-toggle">
           <button
             className={`mode-option ${mode === 'competitive' ? 'active' : ''}`}
-            // leaving casual: 5V5 is disabled for competitive, so drop back to 4V4
-            onClick={() => onDone({ ...settings, mode: 'competitive', format: format === '5V5' ? '4V4' : format })}
+            // keep the chosen format (5V5 is now allowed in competitive too)
+            onClick={() => onDone({ ...settings, mode: 'competitive', format })}
           >
             COMPETITIVE
           </button>
@@ -37,15 +37,13 @@ function ModifyGameModal({ settings, onClose, onDone }) {
         {mode === 'competitive' && (
           <div className="format-row">
             {FORMATS.map(f => {
-              const disabled = f === '5V5';
               const active = format === f;
               return (
                 <button
                   key={f}
-                  className={`format-btn ${active ? 'active' : ''} ${disabled ? 'disabled' : ''}`}
-                  onClick={() => !disabled && update('format', f)}
-                  disabled={disabled}
-                  aria-label={disabled ? `${f} — coming soon` : f}
+                  className={`format-btn ${active ? 'active' : ''}`}
+                  onClick={() => update('format', f)}
+                  aria-label={f}
                 >
                   {f}
                 </button>


### PR DESCRIPTION
## Summary

Fixes the Game Details screen overflow and enables 5v5 games, sizing the lobby + details rosters so a full 5-person side fits cleanly. UI/format changes only.

### Changes
- **Game Details title overflow** — capped `.gd-title` at `clamp(3.5rem, 18vw, 5.5rem)` so the 7-char "DETAILS" fits the 430px frame (same fix already shipped for Finding Game's "FINDING"; the shared `--text-hero` token is tuned for the 4-char "PLAY"/"NOW" hero).
- **Enable 5v5** — un-gated the `5V5` format button for competitive in `ModifyGameModal` (was disabled) and stopped forcing `5V5→4V4` when switching to competitive. Backend already supports `numVS=5` (matchmaker + party-invite default).
- **Fit 5-per-side rosters** — shrank player bubbles to 60px and pack 5 per row on both Finding Game and Game Details, so a full 5-person team stays on one row and a 10-player casual lobby fits 2 rows instead of 3 — preventing the vertical crowding/clipping that showed up at 9–10 players.

### Testing
- Verified bubble layout for 5v5 (competitive teams + casual grid) and the 9–10 player lobby via temporary in-tree mocks (reverted, not included).
- Ran a real matchmaking test end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)