### PR TITLE
Fix waiting-captain hang + drop has_ball (lobby toggle only)

### DIFF
--- a/src/Screens/FindingGameScreen.js
+++ b/src/Screens/FindingGameScreen.js
@@ -21,15 +21,16 @@ function FindingGameScreen() {
 
   const mode = state?.mode ?? 'casual';
   const numVs = state?.numVs ?? 4;
-  const haveBall = state?.haveBall ?? false;
   const maxPlayers = numVs > 0 ? numVs * 2 : null; // total slots; null when "any"
 
   const [gameId, setGameId] = useState(null);
-  const [players, setPlayers] = useState([]); // { user_id, team_side, username, has_ball, is_captain }
+  const [players, setPlayers] = useState([]); // { user_id, team_side, username, is_captain }
   const [parkName, setParkName] = useState('');
   const [showGameChat, setShowGameChat] = useState(false);
 
-  // ── Stage 1: discover my game, and stamp my "have ball" choice on my own row ──
+  // ── Stage 1: discover my game ──
+  // "Have ball" is captured by the lobby toggle only (no DB column, no dot), so
+  // there's nothing to persist here.
   useEffect(() => {
     if (!user) return;
     let cancelled = false;
@@ -39,27 +40,22 @@ function FindingGameScreen() {
       const { data: appUser } = await supabase
         .from('app_user').select('user_id').eq('auth_id', user.id).maybeSingle();
       if (!appUser || cancelled) return;
-      const myUserId = appUser.user_id;
-
-      const markBall = () =>
-        supabase.from('game_player').update({ has_ball: haveBall }).eq('user_id', myUserId);
+      const uid = appUser.user_id;
 
       const { data: existing } = await supabase
-        .from('game_player').select('game_id').eq('user_id', myUserId).maybeSingle();
+        .from('game_player').select('game_id').eq('user_id', uid).maybeSingle();
       if (existing && !cancelled) {
-        await markBall();
         setGameId(existing.game_id);
         return;
       }
 
       channel = supabase
-        .channel(`find-me-${myUserId}`)
+        .channel(`find-me-${uid}`)
         .on(
           'postgres_changes',
-          { event: 'INSERT', schema: 'public', table: 'game_player', filter: `user_id=eq.${myUserId}` },
+          { event: 'INSERT', schema: 'public', table: 'game_player', filter: `user_id=eq.${uid}` },
           (payload) => {
             if (cancelled) return;
-            markBall();
             setGameId(payload.new.game_id);
           }
         )
@@ -67,7 +63,7 @@ function FindingGameScreen() {
     })();
 
     return () => { cancelled = true; if (channel) supabase.removeChannel(channel); };
-  }, [user?.id, haveBall]);
+  }, [user?.id]);
 
   // ── Stage 2: watch my game's roster (with usernames) + readiness ──
   useEffect(() => {
@@ -80,13 +76,12 @@ function FindingGameScreen() {
     async function loadRoster() {
       const { data } = await supabase
         .from('game_player')
-        .select('user_id, team_side, has_ball, is_captain, app_user(username)')
+        .select('user_id, team_side, is_captain, app_user(username)')
         .eq('game_id', gameId);
       if (cancelled || !data) return;
       setPlayers(data.map((r) => ({
         user_id: r.user_id,
         team_side: r.team_side,
-        has_ball: r.has_ball,
         is_captain: r.is_captain,
         username: r.app_user?.username ?? null,
       })));
@@ -155,7 +150,7 @@ function FindingGameScreen() {
         <span className="fg-players-label">PLAYERS</span>
         <div className="fg-dots">
           {players.map((p) => (
-            <PlayerDot key={p.user_id} username={p.username} hasBall={p.has_ball} isCaptain={p.is_captain} />
+            <PlayerDot key={p.user_id} username={p.username} isCaptain={p.is_captain} />
           ))}
           {Array.from({ length: emptyCount }).map((_, i) => (
             <PlayerDot key={`empty-${i}`} empty />

--- a/src/Screens/GameDetailsScreen.js
+++ b/src/Screens/GameDetailsScreen.js
@@ -70,7 +70,6 @@ function GameDetailsScreen() {
         user_id: r.user_id,
         team_side: r.team_side,
         username: r.app_user?.username ?? null,
-        has_ball: r.has_ball,                 // undefined until the column exists
         is_captain: captainIds.has(r.user_id),
       }));
 
@@ -166,7 +165,7 @@ function GameDetailsScreen() {
             <span className="gd-team-label">YOUR TEAM</span>
             <div className="gd-circles-row">
               {yourTeam.map(p => (
-                <PlayerDot key={p.user_id} isCaptain={p.is_captain} hasBall={p.has_ball} username={p.username} />
+                <PlayerDot key={p.user_id} isCaptain={p.is_captain} username={p.username} />
               ))}
             </div>
           </div>
@@ -174,7 +173,7 @@ function GameDetailsScreen() {
             <span className="gd-team-label">THEIR TEAM</span>
             <div className="gd-circles-row">
               {theirTeam.map(p => (
-                <PlayerDot key={p.user_id} isCaptain={p.is_captain} hasBall={p.has_ball} username={p.username} />
+                <PlayerDot key={p.user_id} isCaptain={p.is_captain} username={p.username} />
               ))}
             </div>
           </div>
@@ -184,7 +183,7 @@ function GameDetailsScreen() {
           <span className="gd-team-label">PLAYERS</span>
           <div className="gd-circles-grid">
             {roster.map(p => (
-              <PlayerDot key={p.user_id} isCaptain={p.is_captain} hasBall={p.has_ball} username={p.username} />
+              <PlayerDot key={p.user_id} isCaptain={p.is_captain} username={p.username} />
             ))}
           </div>
         </div>

--- a/src/Screens/PostGameScreen.js
+++ b/src/Screens/PostGameScreen.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { supabase } from '../supabaseClient';
 import './PostGameScreen.css';
@@ -32,6 +32,38 @@ function PostGameScreen() {
   function goRate() {
     navigate('/RatingScreen', { state: { gameId, mySide } });
   }
+
+  // While this captain waits, the other captain's confirmation (finalize) — or a
+  // force-end after repeated disputes — deletes the game row. Watch for that and
+  // auto-advance to ratings; otherwise the first reporter is stuck on "waiting"
+  // forever once the other one selects.
+  useEffect(() => {
+    if (phase !== 'waiting' || usingMock || gameId == null) return;
+    let done = false;
+    const advance = () => {
+      if (done) return;
+      done = true;
+      navigate('/RatingScreen', { state: { gameId, mySide } });
+    };
+
+    // Guard the race where finalize happened before this subscription attached.
+    (async () => {
+      const { data } = await supabase
+        .from('game').select('game_id').eq('game_id', gameId).maybeSingle();
+      if (!data) advance();
+    })();
+
+    const channel = supabase
+      .channel(`postgame-${gameId}`)
+      .on(
+        'postgres_changes',
+        { event: 'DELETE', schema: 'public', table: 'game', filter: `game_id=eq.${gameId}` },
+        advance
+      )
+      .subscribe();
+
+    return () => { done = true; supabase.removeChannel(channel); };
+  }, [phase, usingMock, gameId, mySide, navigate]);
 
   async function handleResult(result) {
     if (submitting) return;


### PR DESCRIPTION
## Summary

Two bug fixes. No captain-assignment logic changed (`is_captain` / `game_captains` RPC left exactly as on `dev`).

### 1. Win/loss reporting — first reporter was stuck on "waiting"
`report_game_result` finalizes by setting `game_history_player.won`, updating stats, and **deleting the `game` row**. The second captain to report gets `'finalized'` and advances, but the first captain (in the `'recorded'`/waiting state) had **no listener** — so they sat on "Waiting for the other captain to confirm" forever once the other selected.

**Fix:** while waiting, `PostGameScreen` subscribes to the `game` row `DELETE` and auto-advances to ratings (also covers the `ended_no_result` force-end). Includes a guard for the race where finalize lands before the subscription attaches.

### 2. Have ball — make it client-only (no DB column)
There is no `has_ball` column and we don't want one. The lobby roster select referenced the non-existent column and the update was a silent no-op.

**Fix:** removed all `has_ball` DB reads/writes. No ball dot is rendered on player circles. The only have-ball UI is the **`HAVE BALL` ✓ toggle** in the settings modal, left fully intact.

### Notes / follow-ups
- Bug #1 needs two captains to fully verify the waiting→finalize transition (hard to test solo).
- Pre-existing: the lobby query still selects `is_captain` (per a code comment, that column may not exist on `game_player`). Intentionally left unchanged — flagged for a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)